### PR TITLE
Replace tools textarea with checkbox group, reorder navigation

### DIFF
--- a/app/Models/Agent.php
+++ b/app/Models/Agent.php
@@ -20,7 +20,6 @@ class Agent extends Model
         'enabled',
         'description',
         'tools',
-        'disallowed_tools',
         'events',
         'provider',
         'model',
@@ -35,7 +34,6 @@ class Agent extends Model
         return [
             'enabled' => 'boolean',
             'tools' => 'array',
-            'disallowed_tools' => 'array',
             'events' => 'array',
             'background' => 'boolean',
         ];

--- a/database/factories/AgentFactory.php
+++ b/database/factories/AgentFactory.php
@@ -23,7 +23,6 @@ class AgentFactory extends Factory
             'enabled' => true,
             'description' => fake()->sentence(),
             'tools' => [],
-            'disallowed_tools' => [],
             'events' => [],
             'provider' => fake()->randomElement(['anthropic', 'openai']),
             'model' => 'inherit',

--- a/database/migrations/2026_03_07_152244_drop_disallowed_tools_from_agents_table.php
+++ b/database/migrations/2026_03_07_152244_drop_disallowed_tools_from_agents_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('agents', function (Blueprint $table) {
+            $table->dropColumn('disallowed_tools');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('agents', function (Blueprint $table) {
+            $table->json('disallowed_tools')->nullable();
+        });
+    }
+};

--- a/resources/views/layouts/app/sidebar.blade.php
+++ b/resources/views/layouts/app/sidebar.blade.php
@@ -21,20 +21,20 @@
                     <flux:sidebar.item icon="building-office" :href="route('organizations.index')" :current="request()->routeIs('organizations.*')" wire:navigate>
                         {{ __('Organizations') }}
                     </flux:sidebar.item>
-                    <flux:sidebar.item icon="cpu-chip" :href="route('agents.index')" :current="request()->routeIs('agents.*')" wire:navigate>
-                        {{ __('Agents') }}
+                    <flux:sidebar.item icon="rectangle-stack" :href="route('projects.index')" :current="request()->routeIs('projects.*')" wire:navigate>
+                        {{ __('Projects') }}
                     </flux:sidebar.item>
                     <flux:sidebar.item icon="folder-git-2" :href="route('repos.index')" :current="request()->routeIs('repos.*')" wire:navigate>
                         {{ __('Repos') }}
                     </flux:sidebar.item>
-                    <flux:sidebar.item icon="bolt" :href="route('skills.index')" :current="request()->routeIs('skills.*')" wire:navigate>
-                        {{ __('Skills') }}
-                    </flux:sidebar.item>
-                    <flux:sidebar.item icon="rectangle-stack" :href="route('projects.index')" :current="request()->routeIs('projects.*')" wire:navigate>
-                        {{ __('Projects') }}
-                    </flux:sidebar.item>
                     <flux:sidebar.item icon="clipboard-document-list" :href="route('work-items.index')" :current="request()->routeIs('work-items.*')" wire:navigate>
                         {{ __('Work Items') }}
+                    </flux:sidebar.item>
+                    <flux:sidebar.item icon="cpu-chip" :href="route('agents.index')" :current="request()->routeIs('agents.*')" wire:navigate>
+                        {{ __('Agents') }}
+                    </flux:sidebar.item>
+                    <flux:sidebar.item icon="bolt" :href="route('skills.index')" :current="request()->routeIs('skills.*')" wire:navigate>
+                        {{ __('Skills') }}
                     </flux:sidebar.item>
                 </flux:sidebar.group>
             </flux:sidebar.nav>

--- a/resources/views/pages/agents/⚡create.blade.php
+++ b/resources/views/pages/agents/⚡create.blade.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Ai\ToolRegistry;
 use App\Models\Agent;
 use App\Models\Repo;
 use App\Models\Skill;
@@ -12,8 +13,7 @@ new #[Title('Create Agent')] class extends Component {
     public string $organization_id = '';
     public string $name = '';
     public ?string $description = '';
-    public string $toolsText = '';
-    public string $disallowedToolsText = '';
+    public array $selectedTools = [];
     public ?string $provider = '';
     public ?string $model = '';
     public ?string $permission_mode = '';
@@ -22,6 +22,12 @@ new #[Title('Create Agent')] class extends Component {
     public ?string $isolation = '';
     public array $selectedSkills = [];
     public array $selectedRepos = [];
+
+    #[Computed]
+    public function availableTools(): array
+    {
+        return array_keys(ToolRegistry::available());
+    }
 
     #[Computed]
     public function organizations(): Collection
@@ -39,6 +45,16 @@ new #[Title('Create Agent')] class extends Component {
     public function repos(): Collection
     {
         return Repo::query()->forUser()->orderBy('name')->get();
+    }
+
+    public function selectAllTools(): void
+    {
+        $this->selectedTools = $this->availableTools;
+    }
+
+    public function deselectAllTools(): void
+    {
+        $this->selectedTools = [];
     }
 
     public function save(): void
@@ -61,8 +77,7 @@ new #[Title('Create Agent')] class extends Component {
             'organization_id' => $this->organization_id,
             'name' => $this->name,
             'description' => $this->description ?: null,
-            'tools' => array_filter(array_map('trim', explode(',', $this->toolsText))),
-            'disallowed_tools' => array_filter(array_map('trim', explode(',', $this->disallowedToolsText))),
+            'tools' => $this->selectedTools,
             'provider' => $this->provider ?: null,
             'model' => $this->model ?: null,
             'permission_mode' => $this->permission_mode ?: null,
@@ -123,9 +138,18 @@ new #[Title('Create Agent')] class extends Component {
                 <option value="true">{{ __('True') }}</option>
             </flux:select>
 
-            <flux:textarea wire:model="toolsText" :label="__('Tools')" :description="__('Comma-separated list of tools')" />
-
-            <flux:textarea wire:model="disallowedToolsText" :label="__('Disallowed Tools')" :description="__('Comma-separated list of disallowed tools')" />
+            <div>
+                <div class="flex items-center gap-2 mb-2">
+                    <flux:heading size="sm">{{ __('Tools') }}</flux:heading>
+                    <flux:button size="xs" wire:click="selectAllTools">{{ __('Check all') }}</flux:button>
+                    <flux:button size="xs" wire:click="deselectAllTools">{{ __('Uncheck all') }}</flux:button>
+                </div>
+                <flux:checkbox.group wire:model="selectedTools">
+                    @foreach ($this->availableTools as $tool)
+                        <flux:checkbox :label="$tool" :value="$tool" />
+                    @endforeach
+                </flux:checkbox.group>
+            </div>
 
             @if ($this->skills->isNotEmpty())
                 <flux:checkbox.group wire:model="selectedSkills" :label="__('Skills')">

--- a/resources/views/pages/agents/⚡edit.blade.php
+++ b/resources/views/pages/agents/⚡edit.blade.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Ai\ToolRegistry;
 use App\Models\Agent;
 use App\Models\Repo;
 use App\Models\Skill;
@@ -14,8 +15,7 @@ new #[Title('Edit Agent')] class extends Component {
     public string $organization_id = '';
     public string $name = '';
     public ?string $description = '';
-    public string $toolsText = '';
-    public string $disallowedToolsText = '';
+    public array $selectedTools = [];
     public ?string $provider = '';
     public ?string $model = '';
     public ?string $permission_mode = '';
@@ -34,8 +34,7 @@ new #[Title('Edit Agent')] class extends Component {
         $this->organization_id = $agent->organization_id;
         $this->name = $agent->name;
         $this->description = $agent->description ?? '';
-        $this->toolsText = implode(', ', $agent->tools ?? []);
-        $this->disallowedToolsText = implode(', ', $agent->disallowed_tools ?? []);
+        $this->selectedTools = $agent->tools ?? [];
         $this->provider = $agent->provider ?? '';
         $this->model = $agent->model ?? '';
         $this->permission_mode = $agent->permission_mode ?? '';
@@ -44,6 +43,12 @@ new #[Title('Edit Agent')] class extends Component {
         $this->isolation = $agent->isolation ?? '';
         $this->selectedSkills = $agent->skills->pluck('id')->toArray();
         $this->selectedRepos = $agent->repos->pluck('id')->toArray();
+    }
+
+    #[Computed]
+    public function availableTools(): array
+    {
+        return array_keys(ToolRegistry::available());
     }
 
     #[Computed]
@@ -62,6 +67,16 @@ new #[Title('Edit Agent')] class extends Component {
     public function repos(): Collection
     {
         return Repo::query()->forUser()->orderBy('name')->get();
+    }
+
+    public function selectAllTools(): void
+    {
+        $this->selectedTools = $this->availableTools;
+    }
+
+    public function deselectAllTools(): void
+    {
+        $this->selectedTools = [];
     }
 
     public function update(): void
@@ -84,8 +99,7 @@ new #[Title('Edit Agent')] class extends Component {
             'organization_id' => $this->organization_id,
             'name' => $this->name,
             'description' => $this->description ?: null,
-            'tools' => array_filter(array_map('trim', explode(',', $this->toolsText))),
-            'disallowed_tools' => array_filter(array_map('trim', explode(',', $this->disallowedToolsText))),
+            'tools' => $this->selectedTools,
             'provider' => $this->provider ?: null,
             'model' => $this->model ?: null,
             'permission_mode' => $this->permission_mode ?: null,
@@ -146,9 +160,18 @@ new #[Title('Edit Agent')] class extends Component {
                 <option value="true">{{ __('True') }}</option>
             </flux:select>
 
-            <flux:textarea wire:model="toolsText" :label="__('Tools')" :description="__('Comma-separated list of tools')" />
-
-            <flux:textarea wire:model="disallowedToolsText" :label="__('Disallowed Tools')" :description="__('Comma-separated list of disallowed tools')" />
+            <div>
+                <div class="flex items-center gap-2 mb-2">
+                    <flux:heading size="sm">{{ __('Tools') }}</flux:heading>
+                    <flux:button size="xs" wire:click="selectAllTools">{{ __('Check all') }}</flux:button>
+                    <flux:button size="xs" wire:click="deselectAllTools">{{ __('Uncheck all') }}</flux:button>
+                </div>
+                <flux:checkbox.group wire:model="selectedTools">
+                    @foreach ($this->availableTools as $tool)
+                        <flux:checkbox :label="$tool" :value="$tool" />
+                    @endforeach
+                </flux:checkbox.group>
+            </div>
 
             @if ($this->skills->isNotEmpty())
                 <flux:checkbox.group wire:model="selectedSkills" :label="__('Skills')">

--- a/resources/views/pages/agents/⚡show.blade.php
+++ b/resources/views/pages/agents/⚡show.blade.php
@@ -102,19 +102,6 @@ new #[Title('View Agent')] class extends Component {
             </div>
 
             <div>
-                <flux:heading size="sm" class="text-zinc-500 dark:text-zinc-400">{{ __('Disallowed Tools') }}</flux:heading>
-                @if (!empty($agent->disallowed_tools))
-                    <div class="flex flex-wrap gap-2 mt-1">
-                        @foreach ($agent->disallowed_tools as $tool)
-                            <flux:badge variant="danger">{{ $tool }}</flux:badge>
-                        @endforeach
-                    </div>
-                @else
-                    <flux:text>{{ __('None') }}</flux:text>
-                @endif
-            </div>
-
-            <div>
                 <flux:heading size="sm" class="text-zinc-500 dark:text-zinc-400">{{ __('Skills') }}</flux:heading>
                 @if ($agent->skills->isNotEmpty())
                     <div class="flex flex-wrap gap-2 mt-1">

--- a/resources/views/pages/organizations/⚡show.blade.php
+++ b/resources/views/pages/organizations/⚡show.blade.php
@@ -76,30 +76,30 @@ new #[Title('Organization')] class extends Component {
                 <flux:text>{{ __('Users') }}</flux:text>
             </div>
 
-            <flux:link href="{{ route('agents.index') }}" wire:navigate class="block rounded-lg border p-4 text-center">
-                <flux:text class="text-2xl font-bold">{{ $organization->agents_count }}</flux:text>
-                <flux:text>{{ __('Agents') }}</flux:text>
-            </flux:link>
-
-            <flux:link href="{{ route('repos.index') }}" wire:navigate class="block rounded-lg border p-4 text-center">
-                <flux:text class="text-2xl font-bold">{{ $organization->repos_count }}</flux:text>
-                <flux:text>{{ __('Repos') }}</flux:text>
-            </flux:link>
-
-            <flux:link href="{{ route('skills.index') }}" wire:navigate class="block rounded-lg border p-4 text-center">
-                <flux:text class="text-2xl font-bold">{{ $organization->skills_count }}</flux:text>
-                <flux:text>{{ __('Skills') }}</flux:text>
-            </flux:link>
-
-            <flux:link href="{{ route('projects.index') }}" wire:navigate class="block rounded-lg border p-4 text-center">
+            <a href="{{ route('projects.index') }}" wire:navigate class="block rounded-lg border p-4 text-center hover:bg-zinc-50 dark:hover:bg-zinc-700/50">
                 <flux:text class="text-2xl font-bold">{{ $organization->projects_count }}</flux:text>
                 <flux:text>{{ __('Projects') }}</flux:text>
-            </flux:link>
+            </a>
 
-            <flux:link href="{{ route('work-items.index') }}" wire:navigate class="block rounded-lg border p-4 text-center">
+            <a href="{{ route('repos.index') }}" wire:navigate class="block rounded-lg border p-4 text-center hover:bg-zinc-50 dark:hover:bg-zinc-700/50">
+                <flux:text class="text-2xl font-bold">{{ $organization->repos_count }}</flux:text>
+                <flux:text>{{ __('Repos') }}</flux:text>
+            </a>
+
+            <a href="{{ route('work-items.index') }}" wire:navigate class="block rounded-lg border p-4 text-center hover:bg-zinc-50 dark:hover:bg-zinc-700/50">
                 <flux:text class="text-2xl font-bold">{{ $organization->work_items_count }}</flux:text>
                 <flux:text>{{ __('Work Items') }}</flux:text>
-            </flux:link>
+            </a>
+
+            <a href="{{ route('agents.index') }}" wire:navigate class="block rounded-lg border p-4 text-center hover:bg-zinc-50 dark:hover:bg-zinc-700/50">
+                <flux:text class="text-2xl font-bold">{{ $organization->agents_count }}</flux:text>
+                <flux:text>{{ __('Agents') }}</flux:text>
+            </a>
+
+            <a href="{{ route('skills.index') }}" wire:navigate class="block rounded-lg border p-4 text-center hover:bg-zinc-50 dark:hover:bg-zinc-700/50">
+                <flux:text class="text-2xl font-bold">{{ $organization->skills_count }}</flux:text>
+                <flux:text>{{ __('Skills') }}</flux:text>
+            </a>
         </div>
 
         <flux:modal name="confirm-delete">

--- a/resources/views/pages/⚡dashboard.blade.php
+++ b/resources/views/pages/⚡dashboard.blade.php
@@ -58,9 +58,9 @@ new #[Title('Dashboard')] class extends Component {
                 <flux:heading size="xl" class="mt-2">{{ $this->organizationCount }}</flux:heading>
             </a>
 
-            <a href="{{ route('agents.index') }}" wire:navigate class="rounded-xl border border-neutral-200 p-6 transition hover:bg-zinc-50 dark:border-neutral-700 dark:hover:bg-zinc-700/50">
-                <flux:heading size="sm" class="text-zinc-500 dark:text-zinc-400">{{ __('Agents') }}</flux:heading>
-                <flux:heading size="xl" class="mt-2">{{ $this->agentCount }}</flux:heading>
+            <a href="{{ route('projects.index') }}" wire:navigate class="rounded-xl border border-neutral-200 p-6 transition hover:bg-zinc-50 dark:border-neutral-700 dark:hover:bg-zinc-700/50">
+                <flux:heading size="sm" class="text-zinc-500 dark:text-zinc-400">{{ __('Projects') }}</flux:heading>
+                <flux:heading size="xl" class="mt-2">{{ $this->projectCount }}</flux:heading>
             </a>
 
             <a href="{{ route('repos.index') }}" wire:navigate class="rounded-xl border border-neutral-200 p-6 transition hover:bg-zinc-50 dark:border-neutral-700 dark:hover:bg-zinc-700/50">
@@ -68,19 +68,19 @@ new #[Title('Dashboard')] class extends Component {
                 <flux:heading size="xl" class="mt-2">{{ $this->repoCount }}</flux:heading>
             </a>
 
-            <a href="{{ route('skills.index') }}" wire:navigate class="rounded-xl border border-neutral-200 p-6 transition hover:bg-zinc-50 dark:border-neutral-700 dark:hover:bg-zinc-700/50">
-                <flux:heading size="sm" class="text-zinc-500 dark:text-zinc-400">{{ __('Skills') }}</flux:heading>
-                <flux:heading size="xl" class="mt-2">{{ $this->skillCount }}</flux:heading>
-            </a>
-
-            <a href="{{ route('projects.index') }}" wire:navigate class="rounded-xl border border-neutral-200 p-6 transition hover:bg-zinc-50 dark:border-neutral-700 dark:hover:bg-zinc-700/50">
-                <flux:heading size="sm" class="text-zinc-500 dark:text-zinc-400">{{ __('Projects') }}</flux:heading>
-                <flux:heading size="xl" class="mt-2">{{ $this->projectCount }}</flux:heading>
-            </a>
-
             <a href="{{ route('work-items.index') }}" wire:navigate class="rounded-xl border border-neutral-200 p-6 transition hover:bg-zinc-50 dark:border-neutral-700 dark:hover:bg-zinc-700/50">
                 <flux:heading size="sm" class="text-zinc-500 dark:text-zinc-400">{{ __('Work Items') }}</flux:heading>
                 <flux:heading size="xl" class="mt-2">{{ $this->workItemCount }}</flux:heading>
+            </a>
+
+            <a href="{{ route('agents.index') }}" wire:navigate class="rounded-xl border border-neutral-200 p-6 transition hover:bg-zinc-50 dark:border-neutral-700 dark:hover:bg-zinc-700/50">
+                <flux:heading size="sm" class="text-zinc-500 dark:text-zinc-400">{{ __('Agents') }}</flux:heading>
+                <flux:heading size="xl" class="mt-2">{{ $this->agentCount }}</flux:heading>
+            </a>
+
+            <a href="{{ route('skills.index') }}" wire:navigate class="rounded-xl border border-neutral-200 p-6 transition hover:bg-zinc-50 dark:border-neutral-700 dark:hover:bg-zinc-700/50">
+                <flux:heading size="sm" class="text-zinc-500 dark:text-zinc-400">{{ __('Skills') }}</flux:heading>
+                <flux:heading size="xl" class="mt-2">{{ $this->skillCount }}</flux:heading>
             </a>
         </div>
     </div>

--- a/tests/Feature/AgentCrudTest.php
+++ b/tests/Feature/AgentCrudTest.php
@@ -30,16 +30,14 @@ it('can create an agent', function () {
         ->set('max_turns', 10)
         ->set('background', false)
         ->set('isolation', 'false')
-        ->set('toolsText', 'read, write, edit')
-        ->set('disallowedToolsText', 'bash')
+        ->set('selectedTools', ['read', 'write', 'edit'])
         ->call('save')
         ->assertHasNoErrors()
         ->assertRedirect();
 
     $agent = Agent::where('name', 'test-agent')->first();
     expect($agent)->not->toBeNull()
-        ->and($agent->tools)->toBe(['read', 'write', 'edit'])
-        ->and($agent->disallowed_tools)->toBe(['bash']);
+        ->and($agent->tools)->toBe(['read', 'write', 'edit']);
 });
 
 it('validates required fields on create', function () {
@@ -62,7 +60,7 @@ it('can update an agent', function () {
     Livewire\Livewire::actingAs($this->user)
         ->test('pages::agents.edit', ['agent' => $this->agent])
         ->set('name', 'updated-agent')
-        ->set('toolsText', 'grep, glob')
+        ->set('selectedTools', ['grep', 'glob'])
         ->call('update')
         ->assertHasNoErrors()
         ->assertRedirect();

--- a/tests/Feature/AgentTest.php
+++ b/tests/Feature/AgentTest.php
@@ -26,13 +26,6 @@ it('casts tools as array', function () {
     expect($agent->tools)->toBe(['tool1', 'tool2']);
 });
 
-it('casts disallowed_tools as array', function () {
-    $agent = Agent::factory()->create(['disallowed_tools' => ['bad_tool']]);
-    $agent->refresh();
-
-    expect($agent->disallowed_tools)->toBe(['bad_tool']);
-});
-
 it('casts background as boolean', function () {
     $agent = Agent::factory()->create(['background' => true]);
     $agent->refresh();


### PR DESCRIPTION
## Summary
- Replace comma-separated tools/disallowed_tools textareas with checkbox group sourced from ToolRegistry
- Add Check all / Uncheck all buttons for tool selection
- Drop disallowed_tools column from agents table
- Reorder sidebar nav and dashboard widgets: Organizations, Projects, Repos, Work Items, Agents, Skills
- Fix organization show page grid by replacing flux:link with plain anchor tags

## Test plan
- [ ] Run `php artisan test --compact --filter=Agent` — all tests pass
- [ ] Verify agent create/edit forms show tool checkboxes
- [ ] Verify sidebar and dashboard widget order matches new ordering
- [ ] Verify organization show page widgets render in grid layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)