### PR TITLE
Exclude MCP and OAuth routes from CSRF verification, simplify MCP endpoint

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -12,7 +12,10 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->validateCsrfTokens(except: [
+            'mcp/*',
+            'oauth/*',
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/routes/ai.php
+++ b/routes/ai.php
@@ -5,7 +5,7 @@ use Laravel\Mcp\Facades\Mcp;
 
 Mcp::oauthRoutes();
 
-Mcp::web('/mcp/github', GitHubServer::class)
+Mcp::web('/mcp', GitHubServer::class)
     ->middleware('auth:api');
 
 Mcp::local('github', GitHubServer::class);


### PR DESCRIPTION
## Summary

- Excludes `mcp/*` and `oauth/*` routes from CSRF token verification in `bootstrap/app.php`
- Simplifies MCP server endpoint from `/mcp/github` to `/mcp`
- Fixes 419 "Page Expired" errors when MCP clients attempt to connect via HTTP

## Context

The Laravel MCP package loads `routes/ai.php` using `Route::group([], ...)` with no middleware group, so routes inherit the web middleware stack including CSRF verification. Stateless MCP and OAuth endpoints don't send CSRF tokens, causing 419 errors.

## Test plan

- [x] All 210 existing tests pass
- [ ] Verify MCP client can connect without 419 error
- [ ] Verify OAuth flow completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)