### PR TITLE
Split MCP into GitHub and Pageant servers

### DIFF
--- a/app/Mcp/Servers/GitHubServer.php
+++ b/app/Mcp/Servers/GitHubServer.php
@@ -4,7 +4,6 @@ namespace App\Mcp\Servers;
 
 use App\Mcp\Tools\AddLabelsToIssueTool;
 use App\Mcp\Tools\CloseIssueTool;
-use App\Mcp\Tools\CreateAgentTool;
 use App\Mcp\Tools\CreateBranchTool;
 use App\Mcp\Tools\CreateCommentTool;
 use App\Mcp\Tools\CreateIssueTool;
@@ -12,10 +11,8 @@ use App\Mcp\Tools\CreateLabelTool;
 use App\Mcp\Tools\CreateOrUpdateFileTool;
 use App\Mcp\Tools\CreatePullRequestReviewTool;
 use App\Mcp\Tools\CreatePullRequestTool;
-use App\Mcp\Tools\CreateWorkItemTool;
 use App\Mcp\Tools\DeleteFileTool;
 use App\Mcp\Tools\DeleteLabelTool;
-use App\Mcp\Tools\DeleteWorkItemTool;
 use App\Mcp\Tools\GetCommitStatusTool;
 use App\Mcp\Tools\GetFileContentsTool;
 use App\Mcp\Tools\GetIssueTool;
@@ -87,13 +84,6 @@ class GitHubServer extends Server
         // Search
         SearchCodeTool::class,
         SearchIssuesTool::class,
-
-        // Work Items
-        CreateWorkItemTool::class,
-        DeleteWorkItemTool::class,
-
-        // Agents
-        CreateAgentTool::class,
 
         // Labels
         ListLabelsTool::class,

--- a/app/Mcp/Servers/PageantServer.php
+++ b/app/Mcp/Servers/PageantServer.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Mcp\Servers;
+
+use App\Mcp\Tools\CreateAgentTool;
+use App\Mcp\Tools\CreateWorkItemTool;
+use App\Mcp\Tools\DeleteWorkItemTool;
+use Laravel\Mcp\Server;
+use Laravel\Mcp\Server\Attributes\Instructions;
+use Laravel\Mcp\Server\Attributes\Name;
+use Laravel\Mcp\Server\Attributes\Version;
+
+#[Name('Pageant Server')]
+#[Version('0.0.1')]
+#[Instructions('Manage Pageant work items and agents.')]
+class PageantServer extends Server
+{
+    protected array $tools = [
+        // Work Items
+        CreateWorkItemTool::class,
+        DeleteWorkItemTool::class,
+
+        // Agents
+        CreateAgentTool::class,
+    ];
+
+    protected array $resources = [
+        //
+    ];
+
+    protected array $prompts = [
+        //
+    ];
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -13,7 +13,7 @@ return Application::configure(basePath: dirname(__DIR__))
     )
     ->withMiddleware(function (Middleware $middleware): void {
         $middleware->validateCsrfTokens(except: [
-            'mcp',
+            'mcp/*',
             'oauth/*',
         ]);
     })

--- a/routes/ai.php
+++ b/routes/ai.php
@@ -1,11 +1,16 @@
 <?php
 
 use App\Mcp\Servers\GitHubServer;
+use App\Mcp\Servers\PageantServer;
 use Laravel\Mcp\Facades\Mcp;
 
 Mcp::oauthRoutes();
 
-Mcp::web('/mcp', GitHubServer::class)
+Mcp::web('/mcp/github', GitHubServer::class)
+    ->middleware('auth:api');
+
+Mcp::web('/mcp/pageant', PageantServer::class)
     ->middleware('auth:api');
 
 Mcp::local('github', GitHubServer::class);
+Mcp::local('pageant', PageantServer::class);

--- a/tests/Feature/CreateAgentToolTest.php
+++ b/tests/Feature/CreateAgentToolTest.php
@@ -1,7 +1,7 @@
 <?php
 
 use App\Ai\ToolRegistry;
-use App\Mcp\Servers\GitHubServer;
+use App\Mcp\Servers\PageantServer;
 use App\Mcp\Tools\CreateAgentTool;
 use App\Models\Agent;
 use App\Models\GithubInstallation;
@@ -21,7 +21,7 @@ beforeEach(function () {
 });
 
 it('creates an agent via MCP tool', function () {
-    $response = GitHubServer::tool(CreateAgentTool::class, [
+    $response = PageantServer::tool(CreateAgentTool::class, [
         'repo' => 'acme/widgets',
         'name' => 'review-bot',
         'description' => 'Reviews pull requests',
@@ -46,7 +46,7 @@ it('creates an agent via MCP tool', function () {
 });
 
 it('creates an agent with defaults via MCP tool', function () {
-    $response = GitHubServer::tool(CreateAgentTool::class, [
+    $response = PageantServer::tool(CreateAgentTool::class, [
         'repo' => 'acme/widgets',
         'name' => 'simple-bot',
     ]);
@@ -70,7 +70,7 @@ it('attaches additional repos via MCP tool', function () {
         'source_reference' => 'acme/gadgets',
     ]);
 
-    $response = GitHubServer::tool(CreateAgentTool::class, [
+    $response = PageantServer::tool(CreateAgentTool::class, [
         'repo' => 'acme/widgets',
         'name' => 'multi-repo-bot',
         'repo_names' => ['acme/gadgets'],

--- a/tests/Feature/McpGitHubToolsTest.php
+++ b/tests/Feature/McpGitHubToolsTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Mcp\Servers\GitHubServer;
+use App\Mcp\Servers\PageantServer;
 use App\Mcp\Tools\AddLabelsToIssueTool;
 use App\Mcp\Tools\CloseIssueTool;
 use App\Mcp\Tools\CreateBranchTool;
@@ -841,7 +842,7 @@ it('creates a work item from a GitHub issue', function () {
             ]);
     });
 
-    $response = GitHubServer::tool(CreateWorkItemTool::class, [
+    $response = PageantServer::tool(CreateWorkItemTool::class, [
         'repo' => 'acme/widgets',
         'issue_number' => 42,
         'board_id' => 'backlog',
@@ -869,7 +870,7 @@ it('deletes a work item by repo and issue number', function () {
         'board_id' => 'backlog',
     ]);
 
-    $response = GitHubServer::tool(DeleteWorkItemTool::class, [
+    $response = PageantServer::tool(DeleteWorkItemTool::class, [
         'repo' => 'acme/widgets',
         'issue_number' => 42,
     ]);


### PR DESCRIPTION
## Summary
- Move WorkItem and Agent tools from `GitHubServer` to a new `PageantServer`
- Route GitHub tools at `/mcp/github` and Pageant tools at `/mcp/pageant`
- Update CSRF exception from `mcp` to `mcp/*` wildcard pattern

## Test plan
- [x] `php artisan route:list --path=mcp` shows routes at `/mcp/github` and `/mcp/pageant`
- [x] All 210 tests pass
- [x] Pint formatting clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)