### PR TITLE
Fix OAuth consent view and add client_id indexes

### DIFF
--- a/database/migrations/2026_03_07_180405_add_client_id_index_to_oauth_tables.php
+++ b/database/migrations/2026_03_07_180405_add_client_id_index_to_oauth_tables.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('oauth_auth_codes', function (Blueprint $table) {
+            $table->index('client_id');
+        });
+
+        Schema::table('oauth_access_tokens', function (Blueprint $table) {
+            $table->index('client_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('oauth_access_tokens', function (Blueprint $table) {
+            $table->dropIndex(['client_id']);
+        });
+
+        Schema::table('oauth_auth_codes', function (Blueprint $table) {
+            $table->dropIndex(['client_id']);
+        });
+    }
+
+    /**
+     * Get the migration connection name.
+     */
+    public function getConnection(): ?string
+    {
+        return $this->connection ?? config('passport.connection');
+    }
+};

--- a/resources/views/mcp/authorize.blade.php
+++ b/resources/views/mcp/authorize.blade.php
@@ -7,7 +7,7 @@
     {{-- Inline script to detect system dark mode preference and apply it immediately --}}
     <script>
         (function() {
-            const appearance = '{{ $appearance ?? "system" }}';
+            const appearance = @json($appearance ?? 'system');
 
             if (appearance === 'system') {
                 const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
@@ -101,7 +101,7 @@
                 <form method="POST" action="{{ route('passport.authorizations.deny') }}" class="flex-1">
                     @csrf
                     @method('DELETE')
-                    <input type="hidden" name="state" value="">
+                    <input type="hidden" name="state" value="{{ $request->state }}">
                     <input type="hidden" name="client_id" value="{{ $client->id }}">
                     <input type="hidden" name="auth_token" value="{{ $authToken }}">
                     <button type="submit" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2 w-full">
@@ -115,7 +115,7 @@
                 <!-- Approve Form -->
                 <form method="POST" action="{{ route('passport.authorizations.approve') }}" class="flex-1" id="authorizeForm">
                     @csrf
-                    <input type="hidden" name="state" value="">
+                    <input type="hidden" name="state" value="{{ $request->state }}">
                     <input type="hidden" name="client_id" value="{{ $client->id }}">
                     <input type="hidden" name="auth_token" value="{{ $authToken }}">
                     <button type="submit" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2 w-full" id="authorizeButton">
@@ -166,7 +166,13 @@
         });
 
         // Handle cancel button...
-        const cancelForm = document.querySelector('form[method="POST"]:has(input[name="_method"][value="DELETE"])');
+        const postForms = document.querySelectorAll('form[method="POST"]');
+        let cancelForm = null;
+        postForms.forEach(function(formElement) {
+            if (formElement.querySelector('input[name="_method"][value="DELETE"]')) {
+                cancelForm = cancelForm || formElement;
+            }
+        });
         if (cancelForm) {
             cancelForm.addEventListener('submit', function(e) {
                 setTimeout(function() {

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,8 +1,1 @@
 <?php
-
-use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Route;
-
-Route::get('/user', function (Request $request) {
-    return $request->user();
-})->middleware('auth:api');


### PR DESCRIPTION
## Summary
Addresses Copilot review feedback from PR #6:

- Populate OAuth `state` parameter in approve/deny forms (was empty string)
- Use `@json()` instead of Blade string interpolation for `$appearance` in JS (XSS prevention)
- Replace CSS `:has()` selector with compatible `forEach` loop for cancel form detection
- Add `client_id` indexes on `oauth_auth_codes` and `oauth_access_tokens` tables (new migration)
- Remove unused `/api/user` route that was not part of the MCP OAuth flow

## Test plan
- [x] `php artisan test --compact` — 210 passed
- [ ] Manual: verify OAuth consent flow preserves state parameter correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)