### PR TITLE
Address Copilot review feedback from PR #9

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -13,7 +13,10 @@ return Application::configure(basePath: dirname(__DIR__))
     )
     ->withMiddleware(function (Middleware $middleware): void {
         $middleware->validateCsrfTokens(except: [
-            'mcp/*',
+            'mcp/github',
+            'mcp/github/*',
+            'mcp/pageant',
+            'mcp/pageant/*',
             'oauth/*',
         ]);
     })

--- a/tests/Feature/McpGitHubToolsTest.php
+++ b/tests/Feature/McpGitHubToolsTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use App\Mcp\Servers\GitHubServer;
-use App\Mcp\Servers\PageantServer;
 use App\Mcp\Tools\AddLabelsToIssueTool;
 use App\Mcp\Tools\CloseIssueTool;
 use App\Mcp\Tools\CreateBranchTool;
@@ -11,10 +10,8 @@ use App\Mcp\Tools\CreateLabelTool;
 use App\Mcp\Tools\CreateOrUpdateFileTool;
 use App\Mcp\Tools\CreatePullRequestReviewTool;
 use App\Mcp\Tools\CreatePullRequestTool;
-use App\Mcp\Tools\CreateWorkItemTool;
 use App\Mcp\Tools\DeleteFileTool;
 use App\Mcp\Tools\DeleteLabelTool;
-use App\Mcp\Tools\DeleteWorkItemTool;
 use App\Mcp\Tools\GetCommitStatusTool;
 use App\Mcp\Tools\GetFileContentsTool;
 use App\Mcp\Tools\GetIssueTool;
@@ -39,7 +36,6 @@ use App\Mcp\Tools\UpdatePullRequestTool;
 use App\Models\GithubInstallation;
 use App\Models\Organization;
 use App\Models\Repo;
-use App\Models\WorkItem;
 use App\Services\GitHubService;
 use Mockery\MockInterface;
 
@@ -825,58 +821,3 @@ it('fails when repo is not tracked', function () {
         'repo' => 'unknown/repo',
     ]);
 })->throws(\Illuminate\Database\Eloquent\ModelNotFoundException::class);
-
-it('creates a work item from a GitHub issue', function () {
-    $this->mock(GitHubService::class, function (MockInterface $mock) {
-        $mock->shouldReceive('getIssue')
-            ->once()
-            ->withArgs(function ($installation, $repo, $issueNumber) {
-                return $repo === 'acme/widgets' && $issueNumber === 42;
-            })
-            ->andReturn([
-                'number' => 42,
-                'title' => 'Fix the widget',
-                'body' => 'The widget is broken',
-                'state' => 'open',
-                'html_url' => 'https://github.com/acme/widgets/issues/42',
-            ]);
-    });
-
-    $response = PageantServer::tool(CreateWorkItemTool::class, [
-        'repo' => 'acme/widgets',
-        'issue_number' => 42,
-        'board_id' => 'backlog',
-    ]);
-
-    $response->assertOk()
-        ->assertSee('Fix the widget');
-
-    $workItem = WorkItem::where('source_reference', 'acme/widgets#42')->first();
-
-    expect($workItem)->not->toBeNull()
-        ->and($workItem->title)->toBe('Fix the widget')
-        ->and($workItem->description)->toBe('The widget is broken')
-        ->and($workItem->board_id)->toBe('backlog')
-        ->and($workItem->source)->toBe('github')
-        ->and($workItem->source_url)->toBe('https://github.com/acme/widgets/issues/42')
-        ->and($workItem->organization_id)->toBe($this->organization->id);
-});
-
-it('deletes a work item by repo and issue number', function () {
-    WorkItem::factory()->create([
-        'organization_id' => $this->organization->id,
-        'source' => 'github',
-        'source_reference' => 'acme/widgets#42',
-        'board_id' => 'backlog',
-    ]);
-
-    $response = PageantServer::tool(DeleteWorkItemTool::class, [
-        'repo' => 'acme/widgets',
-        'issue_number' => 42,
-    ]);
-
-    $response->assertOk()
-        ->assertSee('deleted successfully');
-
-    expect(WorkItem::where('source_reference', 'acme/widgets#42')->exists())->toBeFalse();
-});

--- a/tests/Feature/McpPageantToolsTest.php
+++ b/tests/Feature/McpPageantToolsTest.php
@@ -1,0 +1,78 @@
+<?php
+
+use App\Mcp\Servers\PageantServer;
+use App\Mcp\Tools\CreateWorkItemTool;
+use App\Mcp\Tools\DeleteWorkItemTool;
+use App\Models\GithubInstallation;
+use App\Models\Organization;
+use App\Models\Repo;
+use App\Models\WorkItem;
+use App\Services\GitHubService;
+use Mockery\MockInterface;
+
+beforeEach(function () {
+    $this->organization = Organization::factory()->create();
+    $this->installation = GithubInstallation::factory()->create([
+        'organization_id' => $this->organization->id,
+    ]);
+    $this->repo = Repo::factory()->create([
+        'organization_id' => $this->organization->id,
+        'source' => 'github',
+        'source_reference' => 'acme/widgets',
+    ]);
+});
+
+it('creates a work item from a GitHub issue', function () {
+    $this->mock(GitHubService::class, function (MockInterface $mock) {
+        $mock->shouldReceive('getIssue')
+            ->once()
+            ->withArgs(function ($installation, $repo, $issueNumber) {
+                return $repo === 'acme/widgets' && $issueNumber === 42;
+            })
+            ->andReturn([
+                'number' => 42,
+                'title' => 'Fix the widget',
+                'body' => 'The widget is broken',
+                'state' => 'open',
+                'html_url' => 'https://github.com/acme/widgets/issues/42',
+            ]);
+    });
+
+    $response = PageantServer::tool(CreateWorkItemTool::class, [
+        'repo' => 'acme/widgets',
+        'issue_number' => 42,
+        'board_id' => 'backlog',
+    ]);
+
+    $response->assertOk()
+        ->assertSee('Fix the widget');
+
+    $workItem = WorkItem::where('source_reference', 'acme/widgets#42')->first();
+
+    expect($workItem)->not->toBeNull()
+        ->and($workItem->title)->toBe('Fix the widget')
+        ->and($workItem->description)->toBe('The widget is broken')
+        ->and($workItem->board_id)->toBe('backlog')
+        ->and($workItem->source)->toBe('github')
+        ->and($workItem->source_url)->toBe('https://github.com/acme/widgets/issues/42')
+        ->and($workItem->organization_id)->toBe($this->organization->id);
+});
+
+it('deletes a work item by repo and issue number', function () {
+    WorkItem::factory()->create([
+        'organization_id' => $this->organization->id,
+        'source' => 'github',
+        'source_reference' => 'acme/widgets#42',
+        'board_id' => 'backlog',
+    ]);
+
+    $response = PageantServer::tool(DeleteWorkItemTool::class, [
+        'repo' => 'acme/widgets',
+        'issue_number' => 42,
+    ]);
+
+    $response->assertOk()
+        ->assertSee('deleted successfully');
+
+    expect(WorkItem::where('source_reference', 'acme/widgets#42')->exists())->toBeFalse();
+});


### PR DESCRIPTION
## Summary

- Tighten CSRF exclusions from broad `mcp/*` wildcard to explicit `mcp/github`, `mcp/github/*`, `mcp/pageant`, `mcp/pageant/*` patterns
- Move work-item tool tests from `McpGitHubToolsTest` into new `McpPageantToolsTest` to match server split

Addresses review comments from #9.

## Test plan

- [x] All 210 tests pass
- [x] Pint formatting clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)