### PR TITLE
Add granular event filtering for agents

### DIFF
--- a/app/Ai/EventRegistry.php
+++ b/app/Ai/EventRegistry.php
@@ -4,21 +4,64 @@ namespace App\Ai;
 
 class EventRegistry
 {
-    /** @var array<string, array{description: string, group: string}> */
+    /** @var array<string, array{label: string, description: string, group: string, actions: string[], filters: string[]}> */
     private const EVENT_MAP = [
         // Code
-        'push' => ['description' => 'Code pushed to a branch', 'group' => 'Code'],
+        'push' => [
+            'label' => 'Code',
+            'description' => 'Pushed',
+            'group' => 'Code',
+            'actions' => [],
+            'filters' => ['branches'],
+        ],
 
         // Issues
-        'issues' => ['description' => 'Issue opened, closed, labeled, etc.', 'group' => 'Issues'],
-        'issue_comment' => ['description' => 'Comment on an issue or PR', 'group' => 'Issues'],
+        'issues' => [
+            'label' => 'Issues',
+            'description' => 'Issue opened, closed, labeled, etc.',
+            'group' => 'Issues',
+            'actions' => ['opened', 'edited', 'closed', 'reopened', 'labeled', 'unlabeled', 'assigned', 'unassigned', 'locked', 'unlocked', 'transferred', 'milestoned', 'demilestoned', 'pinned', 'unpinned', 'deleted'],
+            'filters' => ['labels'],
+        ],
+        'issue_comment' => [
+            'label' => 'Comments',
+            'description' => 'Comment on an issue or PR',
+            'group' => 'Issues',
+            'actions' => ['created', 'edited', 'deleted'],
+            'filters' => ['labels'],
+        ],
 
         // Pull Requests
-        'pull_request' => ['description' => 'PR opened, closed, synchronized, etc.', 'group' => 'Pull Requests'],
-        'pull_request_review' => ['description' => 'Review submitted on a PR', 'group' => 'Pull Requests'],
+        'pull_request' => [
+            'label' => 'Pull Requests',
+            'description' => 'PR opened, closed, synchronized, etc.',
+            'group' => 'Pull Requests',
+            'actions' => ['opened', 'edited', 'closed', 'reopened', 'synchronize', 'labeled', 'unlabeled', 'review_requested', 'ready_for_review', 'converted_to_draft', 'locked', 'unlocked'],
+            'filters' => ['labels', 'base_branch'],
+        ],
+        'pull_request_review' => [
+            'label' => 'Reviews',
+            'description' => 'Review submitted on a PR',
+            'group' => 'Pull Requests',
+            'actions' => ['submitted', 'edited', 'dismissed'],
+            'filters' => ['labels', 'base_branch'],
+        ],
 
         // Work Items
-        'work_item_created' => ['description' => 'Work item created in Pageant', 'group' => 'Work Items'],
+        'work_item_created' => [
+            'label' => 'Work Items',
+            'description' => 'Created',
+            'group' => 'Work Items',
+            'actions' => [],
+            'filters' => [],
+        ],
+        'work_item_deleted' => [
+            'label' => 'Work Items',
+            'description' => 'Deleted',
+            'group' => 'Work Items',
+            'actions' => [],
+            'filters' => [],
+        ],
     ];
 
     /**
@@ -38,6 +81,64 @@ class EventRegistry
 
         foreach (self::EVENT_MAP as $name => $entry) {
             $groups[$entry['group']][$name] = $entry['description'];
+        }
+
+        return $groups;
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function actionsFor(string $eventType): array
+    {
+        return self::EVENT_MAP[$eventType]['actions'] ?? [];
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function filtersFor(string $eventType): array
+    {
+        return self::EVENT_MAP[$eventType]['filters'] ?? [];
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function allEventKeys(): array
+    {
+        $keys = [];
+
+        foreach (self::EVENT_MAP as $name => $entry) {
+            $keys[] = $name;
+
+            foreach ($entry['actions'] as $action) {
+                $keys[] = "{$name}.{$action}";
+            }
+        }
+
+        return $keys;
+    }
+
+    public static function isValidEventKey(string $key): bool
+    {
+        return in_array($key, self::allEventKeys(), true);
+    }
+
+    /**
+     * @return array<string, array<string, array{label: string, description: string, actions: string[], filters: string[]}>>
+     */
+    public static function groupedWithDetails(): array
+    {
+        $groups = [];
+
+        foreach (self::EVENT_MAP as $name => $entry) {
+            $groups[$entry['group']][$name] = [
+                'label' => $entry['label'],
+                'description' => $entry['description'],
+                'actions' => $entry['actions'],
+                'filters' => $entry['filters'],
+            ];
         }
 
         return $groups;

--- a/app/Ai/EventSubscription.php
+++ b/app/Ai/EventSubscription.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Ai;
+
+class EventSubscription
+{
+    public function __construct(
+        public string $eventType,
+        public ?string $action = null,
+        public array $filters = [],
+    ) {}
+
+    /**
+     * @param  array{event: string, filters?: array<string, mixed>}  $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $event = $data['event'];
+        $action = null;
+
+        if (str_contains($event, '.')) {
+            [$event, $action] = explode('.', $event, 2);
+        }
+
+        return new self(
+            eventType: $event,
+            action: $action,
+            filters: $data['filters'] ?? [],
+        );
+    }
+
+    /**
+     * @return array{event: string, filters: array<string, mixed>}
+     */
+    public function toArray(): array
+    {
+        $event = $this->action ? "{$this->eventType}.{$this->action}" : $this->eventType;
+
+        return [
+            'event' => $event,
+            'filters' => $this->filters,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $context  Keys: labels (array), base_branch (string), branches (array)
+     */
+    public function matches(string $eventType, ?string $action, array $context = []): bool
+    {
+        if ($this->eventType !== $eventType) {
+            return false;
+        }
+
+        if ($this->action !== null && $this->action !== $action) {
+            return false;
+        }
+
+        if (! empty($this->filters['labels']) && ! empty($context['labels'])) {
+            $contextLabels = array_map('strtolower', $context['labels']);
+            $filterLabels = array_map('strtolower', $this->filters['labels']);
+
+            if (empty(array_intersect($filterLabels, $contextLabels))) {
+                return false;
+            }
+        } elseif (! empty($this->filters['labels']) && empty($context['labels'])) {
+            return false;
+        }
+
+        if (! empty($this->filters['base_branch'])) {
+            if (($context['base_branch'] ?? null) !== $this->filters['base_branch']) {
+                return false;
+            }
+        }
+
+        if (! empty($this->filters['branches'])) {
+            $branch = $context['branch'] ?? null;
+
+            if ($branch === null) {
+                return false;
+            }
+
+            $matched = false;
+
+            foreach ($this->filters['branches'] as $pattern) {
+                if (fnmatch($pattern, $branch)) {
+                    $matched = true;
+                    break;
+                }
+            }
+
+            if (! $matched) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/app/Concerns/DispatchesAgentsForEvent.php
+++ b/app/Concerns/DispatchesAgentsForEvent.php
@@ -2,6 +2,7 @@
 
 namespace App\Concerns;
 
+use App\Ai\EventSubscription;
 use App\Jobs\RunWebhookAgent;
 use App\Models\Repo;
 
@@ -12,8 +13,18 @@ trait DispatchesAgentsForEvent
     // (create_or_update_file, delete_file, merge_pull_request) could be manipulated via
     // prompt injection in these fields. Consider restricting webhook-triggered agents to
     // read-only tools, or adding human approval before executing write operations.
-    protected function dispatchAgentsForRepo(string $repoFullName, string $eventName, string $eventContext, ?int $issueNumber = null): void
-    {
+
+    /**
+     * @param  array<string, mixed>  $filterContext
+     */
+    protected function dispatchAgentsForRepo(
+        string $repoFullName,
+        string $eventType,
+        ?string $action,
+        array $filterContext,
+        string $eventContext,
+        ?int $issueNumber = null,
+    ): void {
         $repo = Repo::where('source', 'github')
             ->where('source_reference', $repoFullName)
             ->first();
@@ -24,11 +35,23 @@ trait DispatchesAgentsForEvent
 
         $agents = $repo->agents()
             ->where('enabled', true)
-            ->whereJsonContains('events', $eventName)
+            ->where('events', 'like', "%{$eventType}%")
             ->get();
 
         foreach ($agents as $agent) {
-            RunWebhookAgent::dispatch($agent, $eventContext, $repoFullName, $issueNumber);
+            $subscriptions = collect($agent->events)->map(function ($entry) {
+                if (is_string($entry)) {
+                    return EventSubscription::fromArray(['event' => $entry, 'filters' => []]);
+                }
+
+                return EventSubscription::fromArray($entry);
+            });
+
+            $matches = $subscriptions->contains(fn (EventSubscription $sub) => $sub->matches($eventType, $action, $filterContext));
+
+            if ($matches) {
+                RunWebhookAgent::dispatch($agent, $eventContext, $repoFullName, $issueNumber);
+            }
         }
     }
 }

--- a/app/Listeners/HandleGitHubComment.php
+++ b/app/Listeners/HandleGitHubComment.php
@@ -26,6 +26,15 @@ class HandleGitHubComment
             "Comment:\n".($comment['body'] ?? ''),
         ]);
 
-        $this->dispatchAgentsForRepo($repoFullName, 'issue_comment', $eventContext, $issue['number']);
+        $labels = array_map(fn (array $l) => $l['name'], $issue['labels'] ?? []);
+
+        $this->dispatchAgentsForRepo(
+            $repoFullName,
+            'issue_comment',
+            $event->action,
+            ['labels' => $labels],
+            $eventContext,
+            $issue['number'],
+        );
     }
 }

--- a/app/Listeners/HandleGitHubIssue.php
+++ b/app/Listeners/HandleGitHubIssue.php
@@ -29,6 +29,15 @@ class HandleGitHubIssue
 
         $eventContext = implode("\n", $lines);
 
-        $this->dispatchAgentsForRepo($repoFullName, 'issues', $eventContext, $issue['number']);
+        $labels = array_map(fn (array $l) => $l['name'], $issue['labels'] ?? []);
+
+        $this->dispatchAgentsForRepo(
+            $repoFullName,
+            'issues',
+            $event->action,
+            ['labels' => $labels],
+            $eventContext,
+            $issue['number'],
+        );
     }
 }

--- a/app/Listeners/HandleGitHubPullRequest.php
+++ b/app/Listeners/HandleGitHubPullRequest.php
@@ -24,6 +24,18 @@ class HandleGitHubPullRequest
             "Body:\n".($pr['body'] ?? '(empty)'),
         ]);
 
-        $this->dispatchAgentsForRepo($repoFullName, 'pull_request', $eventContext, $pr['number']);
+        $labels = array_map(fn (array $l) => $l['name'], $pr['labels'] ?? []);
+
+        $this->dispatchAgentsForRepo(
+            $repoFullName,
+            'pull_request',
+            $event->action,
+            [
+                'labels' => $labels,
+                'base_branch' => $pr['base']['ref'] ?? null,
+            ],
+            $eventContext,
+            $pr['number'],
+        );
     }
 }

--- a/app/Listeners/HandleGitHubPullRequestReview.php
+++ b/app/Listeners/HandleGitHubPullRequestReview.php
@@ -25,6 +25,18 @@ class HandleGitHubPullRequestReview
             "Body:\n".($review['body'] ?? '(empty)'),
         ]);
 
-        $this->dispatchAgentsForRepo($repoFullName, 'pull_request_review', $eventContext, $pr['number']);
+        $labels = array_map(fn (array $l) => $l['name'], $pr['labels'] ?? []);
+
+        $this->dispatchAgentsForRepo(
+            $repoFullName,
+            'pull_request_review',
+            $event->action,
+            [
+                'labels' => $labels,
+                'base_branch' => $pr['base']['ref'] ?? null,
+            ],
+            $eventContext,
+            $pr['number'],
+        );
     }
 }

--- a/app/Listeners/HandleGitHubPush.php
+++ b/app/Listeners/HandleGitHubPush.php
@@ -28,6 +28,14 @@ class HandleGitHubPush
             "Commits:\n{$commits}",
         ]);
 
-        $this->dispatchAgentsForRepo($repoFullName, 'push', $eventContext);
+        $branch = preg_replace('#^refs/heads/#', '', $event->ref);
+
+        $this->dispatchAgentsForRepo(
+            $repoFullName,
+            'push',
+            null,
+            ['branch' => $branch],
+            $eventContext,
+        );
     }
 }

--- a/app/Listeners/HandleWorkItemCreated.php
+++ b/app/Listeners/HandleWorkItemCreated.php
@@ -30,6 +30,13 @@ class HandleWorkItemCreated
             "Source URL: {$workItem->source_url}",
         ]);
 
-        $this->dispatchAgentsForRepo($repoFullName, 'work_item_created', $eventContext, $issueNumber);
+        $this->dispatchAgentsForRepo(
+            $repoFullName,
+            'work_item_created',
+            null,
+            [],
+            $eventContext,
+            $issueNumber,
+        );
     }
 }

--- a/app/Mcp/Tools/CreateAgentTool.php
+++ b/app/Mcp/Tools/CreateAgentTool.php
@@ -26,7 +26,6 @@ class CreateAgentTool extends Tool
             'tools' => 'nullable|array',
             'tools.*' => 'string|in:'.implode(',', array_keys(ToolRegistry::available())),
             'events' => 'nullable|array',
-            'events.*' => 'string|in:'.implode(',', array_keys(EventRegistry::available())),
             'provider' => 'nullable|string|in:anthropic,openai',
             'model' => 'nullable|string',
             'permission_mode' => 'nullable|string|in:full,limited',
@@ -40,12 +39,20 @@ class CreateAgentTool extends Tool
 
         $repo = Repo::where('source', 'github')->where('source_reference', $validated['repo'])->firstOrFail();
 
+        $events = collect($validated['events'] ?? [])->map(function ($entry) {
+            if (is_string($entry)) {
+                return ['event' => $entry, 'filters' => []];
+            }
+
+            return $entry;
+        })->values()->toArray();
+
         $data = [
             'organization_id' => $repo->organization_id,
             'name' => $validated['name'],
             'description' => $validated['description'] ?? '',
             'tools' => $validated['tools'] ?? [],
-            'events' => $validated['events'] ?? [],
+            'events' => $events,
             'provider' => $validated['provider'] ?? 'anthropic',
             'model' => $validated['model'] ?? 'inherit',
             'permission_mode' => $validated['permission_mode'] ?? 'full',
@@ -94,7 +101,7 @@ class CreateAgentTool extends Tool
             'tools' => $schema->array()
                 ->description('Tool names the agent can use. Available: '.implode(', ', array_keys(ToolRegistry::available()))),
             'events' => $schema->array()
-                ->description('Events the agent subscribes to. Available: '.implode(', ', array_keys(EventRegistry::available()))),
+                ->description('Event subscriptions. Each entry is a string (e.g. "issues") or object {"event": "issues.opened", "filters": {"labels": ["bug"]}}. Available event keys: '.implode(', ', EventRegistry::allEventKeys())),
             'provider' => $schema->string()
                 ->description('AI provider: "anthropic" or "openai". Defaults to "anthropic".'),
             'model' => $schema->string()

--- a/database/migrations/2026_03_07_183311_migrate_agent_events_to_subscriptions.php
+++ b/database/migrations/2026_03_07_183311_migrate_agent_events_to_subscriptions.php
@@ -1,0 +1,65 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        DB::table('agents')->whereNotNull('events')->cursor()->each(function ($agent) {
+            $events = json_decode($agent->events, true);
+
+            if (! is_array($events)) {
+                return;
+            }
+
+            $alreadyMigrated = collect($events)->every(fn ($e) => is_array($e) && isset($e['event']));
+
+            if ($alreadyMigrated) {
+                return;
+            }
+
+            $migrated = collect($events)->map(function ($event) {
+                if (is_string($event)) {
+                    return ['event' => $event, 'filters' => []];
+                }
+
+                return $event;
+            })->values()->toArray();
+
+            DB::table('agents')->where('id', $agent->id)->update([
+                'events' => json_encode($migrated),
+            ]);
+        });
+    }
+
+    public function down(): void
+    {
+        DB::table('agents')->whereNotNull('events')->cursor()->each(function ($agent) {
+            $events = json_decode($agent->events, true);
+
+            if (! is_array($events)) {
+                return;
+            }
+
+            $reverted = collect($events)->map(function ($event) {
+                if (is_array($event) && isset($event['event'])) {
+                    $key = $event['event'];
+
+                    if (str_contains($key, '.')) {
+                        [$key] = explode('.', $key, 2);
+                    }
+
+                    return $key;
+                }
+
+                return $event;
+            })->unique()->values()->toArray();
+
+            DB::table('agents')->where('id', $agent->id)->update([
+                'events' => json_encode($reverted),
+            ]);
+        });
+    }
+};

--- a/resources/views/pages/agents/⚡create.blade.php
+++ b/resources/views/pages/agents/⚡create.blade.php
@@ -14,7 +14,8 @@ new #[Title('Create Agent')] class extends Component {
     public string $name = '';
     public ?string $description = '';
     public array $selectedTools = [];
-    public array $selectedEvents = [];
+    public array $selectedEventKeys = [];
+    public array $eventFilters = [];
     public ?string $provider = '';
     public ?string $model = '';
     public ?string $permission_mode = '';
@@ -30,10 +31,41 @@ new #[Title('Create Agent')] class extends Component {
         return ToolRegistry::grouped();
     }
 
+    /**
+     * @return array<int, array{label: string, checkboxes: array<int, array{label: string, value: string}>, filters: array<string, string>}>
+     */
     #[Computed]
-    public function groupedEvents(): array
+    public function eventSections(): array
     {
-        return EventRegistry::grouped();
+        $sections = [];
+
+        foreach (EventRegistry::groupedWithDetails() as $group => $eventTypes) {
+            foreach ($eventTypes as $eventName => $details) {
+                $label = $details['label'];
+                if (! isset($sections[$label])) {
+                    $sections[$label] = ['label' => $label, 'checkboxes' => [], 'filters' => [], 'eventNames' => []];
+                }
+
+                $sections[$label]['eventNames'][] = $eventName;
+
+                if (empty($details['actions'])) {
+                    $sections[$label]['checkboxes'][] = ['label' => $details['description'], 'value' => $eventName];
+                } else {
+                    foreach ($details['actions'] as $action) {
+                        $sections[$label]['checkboxes'][] = [
+                            'label' => ucfirst(str_replace('_', ' ', $action)),
+                            'value' => "{$eventName}.{$action}",
+                        ];
+                    }
+                }
+
+                foreach ($details['filters'] as $filter) {
+                    $sections[$label]['filters'][$eventName][] = $filter;
+                }
+            }
+        }
+
+        return array_values($sections);
     }
 
     #[Computed]
@@ -60,12 +92,80 @@ new #[Title('Create Agent')] class extends Component {
 
     public function selectAllEvents(): void
     {
-        $this->selectedEvents = array_keys(EventRegistry::available());
+        $this->selectedEventKeys = EventRegistry::allEventKeys();
     }
 
     public function deselectAllEvents(): void
     {
-        $this->selectedEvents = [];
+        $this->selectedEventKeys = [];
+        $this->eventFilters = [];
+    }
+
+    protected function buildEventSubscriptions(): array
+    {
+        $subscriptionsByType = [];
+
+        foreach ($this->selectedEventKeys as $key) {
+            if (str_contains($key, '.')) {
+                [$type, $action] = explode('.', $key, 2);
+            } else {
+                $type = $key;
+                $action = null;
+            }
+
+            if (! isset($subscriptionsByType[$type])) {
+                $subscriptionsByType[$type] = [];
+            }
+
+            $subscriptionsByType[$type][] = $action;
+        }
+
+        $subscriptions = [];
+
+        foreach ($subscriptionsByType as $type => $actions) {
+            $allActions = EventRegistry::actionsFor($type);
+            $nonNullActions = array_filter($actions, fn ($a) => $a !== null);
+            $hasBaseType = in_array(null, $actions, true);
+
+            if ($hasBaseType || (count($nonNullActions) === count($allActions) && count($allActions) > 0)) {
+                $event = $type;
+            } else {
+                foreach ($nonNullActions as $action) {
+                    $event = "{$type}.{$action}";
+                    $filters = $this->getFiltersForType($type);
+                    $subscriptions[] = ['event' => $event, 'filters' => $filters];
+                }
+
+                continue;
+            }
+
+            $filters = $this->getFiltersForType($type);
+            $subscriptions[] = ['event' => $event, 'filters' => $filters];
+        }
+
+        return $subscriptions;
+    }
+
+    protected function getFiltersForType(string $type): array
+    {
+        $filters = [];
+        $raw = $this->eventFilters[$type] ?? [];
+
+        if (! empty($raw['labels'])) {
+            $filters['labels'] = array_map('trim', explode(',', $raw['labels']));
+            $filters['labels'] = array_values(array_filter($filters['labels']));
+        }
+
+        if (! empty($raw['base_branch'])) {
+            $filters['base_branch'] = trim($raw['base_branch']);
+        }
+
+        if (! empty($raw['branches'])) {
+            $filters['branches'] = array_map('trim', explode(',', $raw['branches']));
+            $filters['branches'] = array_values(array_filter($filters['branches']));
+        }
+
+        return $filters;
     }
 
     public function save(): void
@@ -88,7 +188,7 @@ new #[Title('Create Agent')] class extends Component {
             'name' => $this->name,
             'description' => $this->description ?: null,
             'tools' => $this->selectedTools,
-            'events' => $this->selectedEvents,
+            'events' => $this->buildEventSubscriptions(),
             'provider' => $this->provider ?: null,
             'model' => $this->model ?: null,
             'permission_mode' => $this->permission_mode ?: null,
@@ -187,15 +287,35 @@ new #[Title('Create Agent')] class extends Component {
                             <flux:button size="xs" wire:click="selectAllEvents">{{ __('Check all') }}</flux:button>
                             <flux:button size="xs" wire:click="deselectAllEvents">{{ __('Uncheck all') }}</flux:button>
                         </div>
-                        <flux:checkbox.group wire:model="selectedEvents">
-                            @foreach ($this->groupedEvents as $group => $events)
+                        <flux:checkbox.group wire:model="selectedEventKeys">
+                            @foreach ($this->eventSections as $section)
                                 <div class="mb-4">
-                                    <flux:heading size="xs" class="mb-2">{{ $group }}</flux:heading>
+                                    <flux:heading size="xs" class="mb-2">{{ $section['label'] }}</flux:heading>
                                     <div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
-                                        @foreach ($events as $name => $description)
-                                            <flux:checkbox :label="$description" :value="$name" />
+                                        @foreach ($section['checkboxes'] as $checkbox)
+                                            <flux:checkbox :label="$checkbox['label']" :value="$checkbox['value']" :description="$checkbox['value']" />
                                         @endforeach
                                     </div>
+
+                                    @foreach ($section['filters'] as $eventName => $filterTypes)
+                                        @php
+                                            $hasSelectedAction = collect($this->selectedEventKeys)->contains(fn ($k) => $k === $eventName || str_starts_with($k, $eventName . '.'));
+                                        @endphp
+                                        @if ($hasSelectedAction)
+                                            <div class="mt-3 space-y-3 border-t border-zinc-200 pt-3 dark:border-zinc-700">
+                                                <flux:text class="text-xs text-zinc-500 dark:text-zinc-400">{{ __('Filters (optional)') }}</flux:text>
+                                                @if (in_array('labels', $filterTypes))
+                                                    <flux:input wire:model="eventFilters.{{ $eventName }}.labels" :label="__('Labels')" placeholder="bug, enhancement" size="sm" />
+                                                @endif
+                                                @if (in_array('base_branch', $filterTypes))
+                                                    <flux:input wire:model="eventFilters.{{ $eventName }}.base_branch" :label="__('Base Branch')" placeholder="main" size="sm" />
+                                                @endif
+                                                @if (in_array('branches', $filterTypes))
+                                                    <flux:input wire:model="eventFilters.{{ $eventName }}.branches" :label="__('Branches')" placeholder="main, release/*" size="sm" />
+                                                @endif
+                                            </div>
+                                        @endif
+                                    @endforeach
                                 </div>
                             @endforeach
                         </flux:checkbox.group>

--- a/resources/views/pages/agents/⚡edit.blade.php
+++ b/resources/views/pages/agents/⚡edit.blade.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Ai\EventRegistry;
+use App\Ai\EventSubscription;
 use App\Ai\ToolRegistry;
 use App\Models\Agent;
 use App\Models\Repo;
@@ -16,7 +17,8 @@ new #[Title('Edit Agent')] class extends Component {
     public string $name = '';
     public ?string $description = '';
     public array $selectedTools = [];
-    public array $selectedEvents = [];
+    public array $selectedEventKeys = [];
+    public array $eventFilters = [];
     public ?string $provider = '';
     public ?string $model = '';
     public ?string $permission_mode = '';
@@ -35,7 +37,7 @@ new #[Title('Edit Agent')] class extends Component {
         $this->name = $agent->name;
         $this->description = $agent->description ?? '';
         $this->selectedTools = $agent->tools ?? [];
-        $this->selectedEvents = $agent->events ?? [];
+        $this->hydrateEventSubscriptions($agent->events ?? []);
         $this->provider = $agent->provider ?? '';
         $this->model = $agent->model ?? '';
         $this->permission_mode = $agent->permission_mode ?? '';
@@ -46,16 +48,96 @@ new #[Title('Edit Agent')] class extends Component {
         $this->selectedRepos = $agent->repos->pluck('id')->toArray();
     }
 
+    protected function hydrateEventSubscriptions(array $events): void
+    {
+        $this->selectedEventKeys = [];
+        $this->eventFilters = [];
+
+        foreach ($events as $entry) {
+            if (is_string($entry)) {
+                $entry = ['event' => $entry, 'filters' => []];
+            }
+
+            $sub = EventSubscription::fromArray($entry);
+            $eventType = $sub->eventType;
+
+            if ($sub->action) {
+                $this->selectedEventKeys[] = "{$eventType}.{$sub->action}";
+            } else {
+                $actions = EventRegistry::actionsFor($eventType);
+
+                if (empty($actions)) {
+                    $this->selectedEventKeys[] = $eventType;
+                } else {
+                    foreach ($actions as $action) {
+                        $this->selectedEventKeys[] = "{$eventType}.{$action}";
+                    }
+                }
+            }
+
+            if (! empty($sub->filters)) {
+                $existing = $this->eventFilters[$eventType] ?? [];
+
+                if (! empty($sub->filters['labels'])) {
+                    $existing['labels'] = implode(', ', $sub->filters['labels']);
+                }
+
+                if (! empty($sub->filters['base_branch'])) {
+                    $existing['base_branch'] = $sub->filters['base_branch'];
+                }
+
+                if (! empty($sub->filters['branches'])) {
+                    $existing['branches'] = implode(', ', $sub->filters['branches']);
+                }
+
+                $this->eventFilters[$eventType] = $existing;
+            }
+        }
+
+        $this->selectedEventKeys = array_values(array_unique($this->selectedEventKeys));
+    }
+
     #[Computed]
     public function groupedTools(): array
     {
         return ToolRegistry::grouped();
     }
 
+    /**
+     * @return array<int, array{label: string, checkboxes: array<int, array{label: string, value: string}>, filters: array<string, string>}>
+     */
     #[Computed]
-    public function groupedEvents(): array
+    public function eventSections(): array
     {
-        return EventRegistry::grouped();
+        $sections = [];
+
+        foreach (EventRegistry::groupedWithDetails() as $group => $eventTypes) {
+            foreach ($eventTypes as $eventName => $details) {
+                $label = $details['label'];
+                if (! isset($sections[$label])) {
+                    $sections[$label] = ['label' => $label, 'checkboxes' => [], 'filters' => [], 'eventNames' => []];
+                }
+
+                $sections[$label]['eventNames'][] = $eventName;
+
+                if (empty($details['actions'])) {
+                    $sections[$label]['checkboxes'][] = ['label' => $details['description'], 'value' => $eventName];
+                } else {
+                    foreach ($details['actions'] as $action) {
+                        $sections[$label]['checkboxes'][] = [
+                            'label' => ucfirst(str_replace('_', ' ', $action)),
+                            'value' => "{$eventName}.{$action}",
+                        ];
+                    }
+                }
+
+                foreach ($details['filters'] as $filter) {
+                    $sections[$label]['filters'][$eventName][] = $filter;
+                }
+            }
+        }
+
+        return array_values($sections);
     }
 
     #[Computed]
@@ -82,12 +164,80 @@ new #[Title('Edit Agent')] class extends Component {
 
     public function selectAllEvents(): void
     {
-        $this->selectedEvents = array_keys(EventRegistry::available());
+        $this->selectedEventKeys = EventRegistry::allEventKeys();
     }
 
     public function deselectAllEvents(): void
     {
-        $this->selectedEvents = [];
+        $this->selectedEventKeys = [];
+        $this->eventFilters = [];
+    }
+
+    protected function buildEventSubscriptions(): array
+    {
+        $subscriptionsByType = [];
+
+        foreach ($this->selectedEventKeys as $key) {
+            if (str_contains($key, '.')) {
+                [$type, $action] = explode('.', $key, 2);
+            } else {
+                $type = $key;
+                $action = null;
+            }
+
+            if (! isset($subscriptionsByType[$type])) {
+                $subscriptionsByType[$type] = [];
+            }
+
+            $subscriptionsByType[$type][] = $action;
+        }
+
+        $subscriptions = [];
+
+        foreach ($subscriptionsByType as $type => $actions) {
+            $allActions = EventRegistry::actionsFor($type);
+            $nonNullActions = array_filter($actions, fn ($a) => $a !== null);
+            $hasBaseType = in_array(null, $actions, true);
+
+            if ($hasBaseType || (count($nonNullActions) === count($allActions) && count($allActions) > 0)) {
+                $event = $type;
+            } else {
+                foreach ($nonNullActions as $action) {
+                    $event = "{$type}.{$action}";
+                    $filters = $this->getFiltersForType($type);
+                    $subscriptions[] = ['event' => $event, 'filters' => $filters];
+                }
+
+                continue;
+            }
+
+            $filters = $this->getFiltersForType($type);
+            $subscriptions[] = ['event' => $event, 'filters' => $filters];
+        }
+
+        return $subscriptions;
+    }
+
+    protected function getFiltersForType(string $type): array
+    {
+        $filters = [];
+        $raw = $this->eventFilters[$type] ?? [];
+
+        if (! empty($raw['labels'])) {
+            $filters['labels'] = array_map('trim', explode(',', $raw['labels']));
+            $filters['labels'] = array_values(array_filter($filters['labels']));
+        }
+
+        if (! empty($raw['base_branch'])) {
+            $filters['base_branch'] = trim($raw['base_branch']);
+        }
+
+        if (! empty($raw['branches'])) {
+            $filters['branches'] = array_map('trim', explode(',', $raw['branches']));
+            $filters['branches'] = array_values(array_filter($filters['branches']));
+        }
+
+        return $filters;
     }
 
     public function update(): void
@@ -106,7 +256,7 @@ new #[Title('Edit Agent')] class extends Component {
             'name' => $this->name,
             'description' => $this->description ?: null,
             'tools' => $this->selectedTools,
-            'events' => $this->selectedEvents,
+            'events' => $this->buildEventSubscriptions(),
             'provider' => $this->provider ?: null,
             'model' => $this->model ?: null,
             'permission_mode' => $this->permission_mode ?: null,
@@ -205,15 +355,35 @@ new #[Title('Edit Agent')] class extends Component {
                             <flux:button size="xs" wire:click="selectAllEvents">{{ __('Check all') }}</flux:button>
                             <flux:button size="xs" wire:click="deselectAllEvents">{{ __('Uncheck all') }}</flux:button>
                         </div>
-                        <flux:checkbox.group wire:model="selectedEvents">
-                            @foreach ($this->groupedEvents as $group => $events)
+                        <flux:checkbox.group wire:model="selectedEventKeys">
+                            @foreach ($this->eventSections as $section)
                                 <div class="mb-4">
-                                    <flux:heading size="xs" class="mb-2">{{ $group }}</flux:heading>
+                                    <flux:heading size="xs" class="mb-2">{{ $section['label'] }}</flux:heading>
                                     <div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
-                                        @foreach ($events as $name => $description)
-                                            <flux:checkbox :label="$description" :value="$name" />
+                                        @foreach ($section['checkboxes'] as $checkbox)
+                                            <flux:checkbox :label="$checkbox['label']" :value="$checkbox['value']" :description="$checkbox['value']" />
                                         @endforeach
                                     </div>
+
+                                    @foreach ($section['filters'] as $eventName => $filterTypes)
+                                        @php
+                                            $hasSelectedAction = collect($this->selectedEventKeys)->contains(fn ($k) => $k === $eventName || str_starts_with($k, $eventName . '.'));
+                                        @endphp
+                                        @if ($hasSelectedAction)
+                                            <div class="mt-3 space-y-3 border-t border-zinc-200 pt-3 dark:border-zinc-700">
+                                                <flux:text class="text-xs text-zinc-500 dark:text-zinc-400">{{ __('Filters (optional)') }}</flux:text>
+                                                @if (in_array('labels', $filterTypes))
+                                                    <flux:input wire:model="eventFilters.{{ $eventName }}.labels" :label="__('Labels')" placeholder="bug, enhancement" size="sm" />
+                                                @endif
+                                                @if (in_array('base_branch', $filterTypes))
+                                                    <flux:input wire:model="eventFilters.{{ $eventName }}.base_branch" :label="__('Base Branch')" placeholder="main" size="sm" />
+                                                @endif
+                                                @if (in_array('branches', $filterTypes))
+                                                    <flux:input wire:model="eventFilters.{{ $eventName }}.branches" :label="__('Branches')" placeholder="main, release/*" size="sm" />
+                                                @endif
+                                            </div>
+                                        @endif
+                                    @endforeach
                                 </div>
                             @endforeach
                         </flux:checkbox.group>

--- a/resources/views/pages/agents/⚡show.blade.php
+++ b/resources/views/pages/agents/⚡show.blade.php
@@ -89,6 +89,35 @@ new #[Title('View Agent')] class extends Component {
             </div>
 
             <div>
+                <flux:heading size="sm" class="text-zinc-500 dark:text-zinc-400">{{ __('Events') }}</flux:heading>
+                @if (!empty($agent->events))
+                    <div class="mt-1 space-y-2">
+                        @foreach ($agent->events as $subscription)
+                            @php
+                                $entry = is_string($subscription) ? ['event' => $subscription, 'filters' => []] : $subscription;
+                                $eventKey = $entry['event'];
+                                $filters = $entry['filters'] ?? [];
+                            @endphp
+                            <div class="flex flex-wrap items-center gap-2">
+                                <flux:badge>{{ $eventKey }}</flux:badge>
+                                @if (!empty($filters['labels']))
+                                    <flux:badge color="blue">labels: {{ implode(', ', $filters['labels']) }}</flux:badge>
+                                @endif
+                                @if (!empty($filters['base_branch']))
+                                    <flux:badge color="green">base: {{ $filters['base_branch'] }}</flux:badge>
+                                @endif
+                                @if (!empty($filters['branches']))
+                                    <flux:badge color="purple">branches: {{ implode(', ', $filters['branches']) }}</flux:badge>
+                                @endif
+                            </div>
+                        @endforeach
+                    </div>
+                @else
+                    <flux:text>{{ __('None') }}</flux:text>
+                @endif
+            </div>
+
+            <div>
                 <flux:heading size="sm" class="text-zinc-500 dark:text-zinc-400">{{ __('Tools') }}</flux:heading>
                 @if (!empty($agent->tools))
                     <div class="flex flex-wrap gap-2 mt-1">

--- a/tests/Feature/AgentCrudTest.php
+++ b/tests/Feature/AgentCrudTest.php
@@ -30,7 +30,7 @@ it('can create an agent', function () {
         ->set('max_turns', 10)
         ->set('background', false)
         ->set('selectedTools', ['read', 'write', 'edit'])
-        ->set('selectedEvents', ['push', 'issues'])
+        ->set('selectedEventKeys', ['push', 'issues.opened'])
         ->call('save')
         ->assertHasNoErrors()
         ->assertRedirect();
@@ -39,7 +39,10 @@ it('can create an agent', function () {
     expect($agent)->not->toBeNull()
         ->and($agent->organization_id)->toBe($this->organization->id)
         ->and($agent->tools)->toBe(['read', 'write', 'edit'])
-        ->and($agent->events)->toBe(['push', 'issues']);
+        ->and($agent->events)->toBe([
+            ['event' => 'push', 'filters' => []],
+            ['event' => 'issues.opened', 'filters' => []],
+        ]);
 });
 
 it('validates required fields on create', function () {
@@ -62,7 +65,7 @@ it('can update an agent', function () {
         ->test('pages::agents.edit', ['agent' => $this->agent])
         ->set('name', 'updated-agent')
         ->set('selectedTools', ['grep', 'glob'])
-        ->set('selectedEvents', ['pull_request', 'push'])
+        ->set('selectedEventKeys', ['pull_request.opened', 'push'])
         ->call('update')
         ->assertHasNoErrors()
         ->assertRedirect();
@@ -70,7 +73,10 @@ it('can update an agent', function () {
     $fresh = $this->agent->fresh();
     expect($fresh->name)->toBe('updated-agent')
         ->and($fresh->tools)->toBe(['grep', 'glob'])
-        ->and($fresh->events)->toBe(['pull_request', 'push']);
+        ->and($fresh->events)->toBe([
+            ['event' => 'pull_request.opened', 'filters' => []],
+            ['event' => 'push', 'filters' => []],
+        ]);
 });
 
 it('can delete an agent', function () {

--- a/tests/Feature/CreateAgentToolTest.php
+++ b/tests/Feature/CreateAgentToolTest.php
@@ -39,10 +39,31 @@ it('creates an agent via MCP tool', function () {
     expect($agent)->not->toBeNull()
         ->and($agent->organization_id)->toBe($this->organization->id)
         ->and($agent->tools)->toBe(['create_comment', 'get_pull_request'])
-        ->and($agent->events)->toBe(['pull_request'])
+        ->and($agent->events)->toBe([['event' => 'pull_request', 'filters' => []]])
         ->and($agent->provider)->toBe('anthropic')
         ->and($agent->enabled)->toBeTrue()
         ->and($agent->repos->pluck('id'))->toContain($this->repo->id);
+});
+
+it('creates an agent with subscription objects via MCP tool', function () {
+    $response = PageantServer::tool(CreateAgentTool::class, [
+        'repo' => 'acme/widgets',
+        'name' => 'filtered-bot',
+        'events' => [
+            ['event' => 'issues.opened', 'filters' => ['labels' => ['bug']]],
+            ['event' => 'pull_request.opened', 'filters' => ['base_branch' => 'main']],
+        ],
+    ]);
+
+    $response->assertOk();
+
+    $agent = Agent::where('name', 'filtered-bot')->first();
+
+    expect($agent)->not->toBeNull()
+        ->and($agent->events)->toBe([
+            ['event' => 'issues.opened', 'filters' => ['labels' => ['bug']]],
+            ['event' => 'pull_request.opened', 'filters' => ['base_branch' => 'main']],
+        ]);
 });
 
 it('creates an agent with defaults via MCP tool', function () {

--- a/tests/Feature/WebhookAgentDispatchTest.php
+++ b/tests/Feature/WebhookAgentDispatchTest.php
@@ -30,7 +30,7 @@ beforeEach(function () {
 it('dispatches RunWebhookAgent for push event when agent subscribes to push', function () {
     $agent = Agent::factory()->create([
         'organization_id' => $this->organization->id,
-        'events' => ['push'],
+        'events' => [['event' => 'push', 'filters' => []]],
         'tools' => ['create_comment'],
     ]);
     $this->repo->agents()->attach($agent);
@@ -53,7 +53,7 @@ it('dispatches RunWebhookAgent for push event when agent subscribes to push', fu
 it('dispatches RunWebhookAgent for pull_request event', function () {
     $agent = Agent::factory()->create([
         'organization_id' => $this->organization->id,
-        'events' => ['pull_request'],
+        'events' => [['event' => 'pull_request', 'filters' => []]],
         'tools' => ['create_comment'],
     ]);
     $this->repo->agents()->attach($agent);
@@ -71,7 +71,7 @@ it('dispatches RunWebhookAgent for pull_request event', function () {
 it('dispatches RunWebhookAgent for pull_request_review event', function () {
     $agent = Agent::factory()->create([
         'organization_id' => $this->organization->id,
-        'events' => ['pull_request_review'],
+        'events' => [['event' => 'pull_request_review', 'filters' => []]],
         'tools' => ['create_comment'],
     ]);
     $this->repo->agents()->attach($agent);
@@ -90,7 +90,7 @@ it('dispatches RunWebhookAgent for pull_request_review event', function () {
 it('dispatches RunWebhookAgent for issue_comment event', function () {
     $agent = Agent::factory()->create([
         'organization_id' => $this->organization->id,
-        'events' => ['issue_comment'],
+        'events' => [['event' => 'issue_comment', 'filters' => []]],
         'tools' => ['create_comment'],
     ]);
     $this->repo->agents()->attach($agent);
@@ -109,7 +109,7 @@ it('dispatches RunWebhookAgent for issue_comment event', function () {
 it('does not dispatch for untracked repos', function () {
     $agent = Agent::factory()->create([
         'organization_id' => $this->organization->id,
-        'events' => ['push'],
+        'events' => [['event' => 'push', 'filters' => []]],
         'tools' => ['create_comment'],
     ]);
     $this->repo->agents()->attach($agent);
@@ -130,13 +130,13 @@ it('only dispatches agents subscribed to the specific event', function () {
     $pushAgent = Agent::factory()->create([
         'organization_id' => $this->organization->id,
         'name' => 'push-agent',
-        'events' => ['push'],
+        'events' => [['event' => 'push', 'filters' => []]],
         'tools' => ['create_comment'],
     ]);
     $prAgent = Agent::factory()->create([
         'organization_id' => $this->organization->id,
         'name' => 'pr-agent',
-        'events' => ['pull_request'],
+        'events' => [['event' => 'pull_request', 'filters' => []]],
         'tools' => ['create_comment'],
     ]);
     $this->repo->agents()->attach([$pushAgent->id, $prAgent->id]);
@@ -159,7 +159,7 @@ it('only dispatches agents subscribed to the specific event', function () {
 it('dispatches RunWebhookAgent for issues event', function () {
     $agent = Agent::factory()->create([
         'organization_id' => $this->organization->id,
-        'events' => ['issues'],
+        'events' => [['event' => 'issues', 'filters' => []]],
         'tools' => ['create_comment'],
     ]);
     $this->repo->agents()->attach($agent);
@@ -181,7 +181,7 @@ it('dispatches RunWebhookAgent for issues event', function () {
 it('does not dispatch when agent is disabled', function () {
     $agent = Agent::factory()->create([
         'organization_id' => $this->organization->id,
-        'events' => ['push'],
+        'events' => [['event' => 'push', 'filters' => []]],
         'tools' => ['create_comment'],
         'enabled' => false,
     ]);
@@ -202,7 +202,7 @@ it('does not dispatch when agent is disabled', function () {
 it('does not dispatch when agent has no matching events', function () {
     $agent = Agent::factory()->create([
         'organization_id' => $this->organization->id,
-        'events' => ['pull_request'],
+        'events' => [['event' => 'pull_request', 'filters' => []]],
         'tools' => ['create_comment'],
     ]);
     $this->repo->agents()->attach($agent);
@@ -217,4 +217,221 @@ it('does not dispatch when agent has no matching events', function () {
     ));
 
     Queue::assertNothingPushed();
+});
+
+// --- Action-level filtering tests ---
+
+it('dispatches only for matching action', function () {
+    $agent = Agent::factory()->create([
+        'organization_id' => $this->organization->id,
+        'events' => [['event' => 'issues.opened', 'filters' => []]],
+        'tools' => ['create_comment'],
+    ]);
+    $this->repo->agents()->attach($agent);
+
+    event(new GitHubIssueReceived(
+        action: 'opened',
+        issue: ['number' => 1, 'title' => 'New', 'body' => '', 'user' => ['login' => 'dev']],
+        repository: ['full_name' => 'acme/widgets'],
+        installationId: 12345,
+    ));
+
+    Queue::assertPushed(RunWebhookAgent::class, 1);
+});
+
+it('does not dispatch for non-matching action', function () {
+    $agent = Agent::factory()->create([
+        'organization_id' => $this->organization->id,
+        'events' => [['event' => 'issues.opened', 'filters' => []]],
+        'tools' => ['create_comment'],
+    ]);
+    $this->repo->agents()->attach($agent);
+
+    event(new GitHubIssueReceived(
+        action: 'closed',
+        issue: ['number' => 1, 'title' => 'New', 'body' => '', 'user' => ['login' => 'dev']],
+        repository: ['full_name' => 'acme/widgets'],
+        installationId: 12345,
+    ));
+
+    Queue::assertNothingPushed();
+});
+
+it('bare event type matches all actions (backward compat)', function () {
+    $agent = Agent::factory()->create([
+        'organization_id' => $this->organization->id,
+        'events' => [['event' => 'issues', 'filters' => []]],
+        'tools' => ['create_comment'],
+    ]);
+    $this->repo->agents()->attach($agent);
+
+    event(new GitHubIssueReceived(
+        action: 'closed',
+        issue: ['number' => 1, 'title' => 'Old', 'body' => '', 'user' => ['login' => 'dev']],
+        repository: ['full_name' => 'acme/widgets'],
+        installationId: 12345,
+    ));
+
+    Queue::assertPushed(RunWebhookAgent::class, 1);
+});
+
+// --- Label filter tests ---
+
+it('dispatches when label filter matches', function () {
+    $agent = Agent::factory()->create([
+        'organization_id' => $this->organization->id,
+        'events' => [['event' => 'issues.opened', 'filters' => ['labels' => ['bug']]]],
+        'tools' => ['create_comment'],
+    ]);
+    $this->repo->agents()->attach($agent);
+
+    event(new GitHubIssueReceived(
+        action: 'opened',
+        issue: ['number' => 1, 'title' => 'Bug', 'body' => '', 'user' => ['login' => 'dev'], 'labels' => [['name' => 'bug'], ['name' => 'priority']]],
+        repository: ['full_name' => 'acme/widgets'],
+        installationId: 12345,
+    ));
+
+    Queue::assertPushed(RunWebhookAgent::class, 1);
+});
+
+it('does not dispatch when label filter does not match', function () {
+    $agent = Agent::factory()->create([
+        'organization_id' => $this->organization->id,
+        'events' => [['event' => 'issues.opened', 'filters' => ['labels' => ['security']]]],
+        'tools' => ['create_comment'],
+    ]);
+    $this->repo->agents()->attach($agent);
+
+    event(new GitHubIssueReceived(
+        action: 'opened',
+        issue: ['number' => 1, 'title' => 'Bug', 'body' => '', 'user' => ['login' => 'dev'], 'labels' => [['name' => 'bug']]],
+        repository: ['full_name' => 'acme/widgets'],
+        installationId: 12345,
+    ));
+
+    Queue::assertNothingPushed();
+});
+
+// --- Base branch filter tests ---
+
+it('dispatches when base_branch filter matches', function () {
+    $agent = Agent::factory()->create([
+        'organization_id' => $this->organization->id,
+        'events' => [['event' => 'pull_request.opened', 'filters' => ['base_branch' => 'main']]],
+        'tools' => ['create_comment'],
+    ]);
+    $this->repo->agents()->attach($agent);
+
+    event(new GitHubPullRequestReceived(
+        action: 'opened',
+        pullRequest: ['number' => 10, 'title' => 'Feature', 'body' => '', 'head' => ['ref' => 'feat'], 'base' => ['ref' => 'main']],
+        repository: ['full_name' => 'acme/widgets'],
+        installationId: 12345,
+    ));
+
+    Queue::assertPushed(RunWebhookAgent::class, 1);
+});
+
+it('does not dispatch when base_branch filter does not match', function () {
+    $agent = Agent::factory()->create([
+        'organization_id' => $this->organization->id,
+        'events' => [['event' => 'pull_request.opened', 'filters' => ['base_branch' => 'main']]],
+        'tools' => ['create_comment'],
+    ]);
+    $this->repo->agents()->attach($agent);
+
+    event(new GitHubPullRequestReceived(
+        action: 'opened',
+        pullRequest: ['number' => 10, 'title' => 'Feature', 'body' => '', 'head' => ['ref' => 'feat'], 'base' => ['ref' => 'develop']],
+        repository: ['full_name' => 'acme/widgets'],
+        installationId: 12345,
+    ));
+
+    Queue::assertNothingPushed();
+});
+
+// --- Branch glob pattern tests ---
+
+it('dispatches when branch glob pattern matches', function () {
+    $agent = Agent::factory()->create([
+        'organization_id' => $this->organization->id,
+        'events' => [['event' => 'push', 'filters' => ['branches' => ['main', 'release/*']]]],
+        'tools' => ['create_comment'],
+    ]);
+    $this->repo->agents()->attach($agent);
+
+    event(new GitHubPushReceived(
+        ref: 'refs/heads/release/v1.0',
+        before: 'aaa111',
+        after: 'bbb222',
+        commits: [],
+        repository: ['full_name' => 'acme/widgets'],
+        installationId: 12345,
+    ));
+
+    Queue::assertPushed(RunWebhookAgent::class, 1);
+});
+
+it('does not dispatch when branch glob pattern does not match', function () {
+    $agent = Agent::factory()->create([
+        'organization_id' => $this->organization->id,
+        'events' => [['event' => 'push', 'filters' => ['branches' => ['main']]]],
+        'tools' => ['create_comment'],
+    ]);
+    $this->repo->agents()->attach($agent);
+
+    event(new GitHubPushReceived(
+        ref: 'refs/heads/feature/foo',
+        before: 'aaa111',
+        after: 'bbb222',
+        commits: [],
+        repository: ['full_name' => 'acme/widgets'],
+        installationId: 12345,
+    ));
+
+    Queue::assertNothingPushed();
+});
+
+// --- Combined filters ---
+
+it('requires all filter types to match (AND logic)', function () {
+    $agent = Agent::factory()->create([
+        'organization_id' => $this->organization->id,
+        'events' => [['event' => 'pull_request.opened', 'filters' => ['labels' => ['bug'], 'base_branch' => 'main']]],
+        'tools' => ['create_comment'],
+    ]);
+    $this->repo->agents()->attach($agent);
+
+    // Labels match but base_branch does not
+    event(new GitHubPullRequestReceived(
+        action: 'opened',
+        pullRequest: ['number' => 10, 'title' => 'Fix', 'body' => '', 'head' => ['ref' => 'fix'], 'base' => ['ref' => 'develop'], 'labels' => [['name' => 'bug']]],
+        repository: ['full_name' => 'acme/widgets'],
+        installationId: 12345,
+    ));
+
+    Queue::assertNothingPushed();
+});
+
+// --- Legacy string format backward compat ---
+
+it('supports legacy string event format', function () {
+    $agent = Agent::factory()->create([
+        'organization_id' => $this->organization->id,
+        'events' => ['push'],
+        'tools' => ['create_comment'],
+    ]);
+    $this->repo->agents()->attach($agent);
+
+    event(new GitHubPushReceived(
+        ref: 'refs/heads/main',
+        before: 'aaa111',
+        after: 'bbb222',
+        commits: [],
+        repository: ['full_name' => 'acme/widgets'],
+        installationId: 12345,
+    ));
+
+    Queue::assertPushed(RunWebhookAgent::class, 1);
 });

--- a/tests/Unit/EventSubscriptionTest.php
+++ b/tests/Unit/EventSubscriptionTest.php
@@ -1,0 +1,171 @@
+<?php
+
+use App\Ai\EventSubscription;
+
+// --- fromArray / toArray ---
+
+it('parses event type without action', function () {
+    $sub = EventSubscription::fromArray(['event' => 'issues', 'filters' => []]);
+
+    expect($sub->eventType)->toBe('issues')
+        ->and($sub->action)->toBeNull()
+        ->and($sub->filters)->toBe([]);
+});
+
+it('parses event type with action', function () {
+    $sub = EventSubscription::fromArray(['event' => 'issues.opened', 'filters' => ['labels' => ['bug']]]);
+
+    expect($sub->eventType)->toBe('issues')
+        ->and($sub->action)->toBe('opened')
+        ->and($sub->filters)->toBe(['labels' => ['bug']]);
+});
+
+it('serializes to array', function () {
+    $sub = new EventSubscription('pull_request', 'opened', ['base_branch' => 'main']);
+
+    expect($sub->toArray())->toBe([
+        'event' => 'pull_request.opened',
+        'filters' => ['base_branch' => 'main'],
+    ]);
+});
+
+it('serializes bare event type to array', function () {
+    $sub = new EventSubscription('push', null, []);
+
+    expect($sub->toArray())->toBe([
+        'event' => 'push',
+        'filters' => [],
+    ]);
+});
+
+// --- matches: event type ---
+
+it('matches same event type', function () {
+    $sub = EventSubscription::fromArray(['event' => 'issues', 'filters' => []]);
+
+    expect($sub->matches('issues', 'opened'))->toBeTrue();
+});
+
+it('does not match different event type', function () {
+    $sub = EventSubscription::fromArray(['event' => 'issues', 'filters' => []]);
+
+    expect($sub->matches('push', null))->toBeFalse();
+});
+
+// --- matches: action filtering ---
+
+it('wildcard action matches any action', function () {
+    $sub = EventSubscription::fromArray(['event' => 'issues', 'filters' => []]);
+
+    expect($sub->matches('issues', 'opened'))->toBeTrue()
+        ->and($sub->matches('issues', 'closed'))->toBeTrue()
+        ->and($sub->matches('issues', 'labeled'))->toBeTrue();
+});
+
+it('specific action only matches that action', function () {
+    $sub = EventSubscription::fromArray(['event' => 'issues.opened', 'filters' => []]);
+
+    expect($sub->matches('issues', 'opened'))->toBeTrue()
+        ->and($sub->matches('issues', 'closed'))->toBeFalse();
+});
+
+// --- matches: label filter ---
+
+it('label filter matches when context has matching label', function () {
+    $sub = EventSubscription::fromArray(['event' => 'issues.opened', 'filters' => ['labels' => ['bug']]]);
+
+    expect($sub->matches('issues', 'opened', ['labels' => ['bug', 'priority']]))->toBeTrue();
+});
+
+it('label filter does not match when context has no matching label', function () {
+    $sub = EventSubscription::fromArray(['event' => 'issues.opened', 'filters' => ['labels' => ['security']]]);
+
+    expect($sub->matches('issues', 'opened', ['labels' => ['bug']]))->toBeFalse();
+});
+
+it('label filter does not match when context has no labels', function () {
+    $sub = EventSubscription::fromArray(['event' => 'issues.opened', 'filters' => ['labels' => ['bug']]]);
+
+    expect($sub->matches('issues', 'opened', ['labels' => []]))->toBeFalse()
+        ->and($sub->matches('issues', 'opened', []))->toBeFalse();
+});
+
+it('label filter is case insensitive', function () {
+    $sub = EventSubscription::fromArray(['event' => 'issues.opened', 'filters' => ['labels' => ['Bug']]]);
+
+    expect($sub->matches('issues', 'opened', ['labels' => ['bug']]))->toBeTrue();
+});
+
+// --- matches: base_branch filter ---
+
+it('base_branch filter matches exact branch', function () {
+    $sub = EventSubscription::fromArray(['event' => 'pull_request.opened', 'filters' => ['base_branch' => 'main']]);
+
+    expect($sub->matches('pull_request', 'opened', ['base_branch' => 'main']))->toBeTrue();
+});
+
+it('base_branch filter does not match different branch', function () {
+    $sub = EventSubscription::fromArray(['event' => 'pull_request.opened', 'filters' => ['base_branch' => 'main']]);
+
+    expect($sub->matches('pull_request', 'opened', ['base_branch' => 'develop']))->toBeFalse();
+});
+
+// --- matches: branches filter (glob) ---
+
+it('branches filter matches exact branch name', function () {
+    $sub = EventSubscription::fromArray(['event' => 'push', 'filters' => ['branches' => ['main']]]);
+
+    expect($sub->matches('push', null, ['branch' => 'main']))->toBeTrue();
+});
+
+it('branches filter matches glob pattern', function () {
+    $sub = EventSubscription::fromArray(['event' => 'push', 'filters' => ['branches' => ['release/*']]]);
+
+    expect($sub->matches('push', null, ['branch' => 'release/v1.0']))->toBeTrue();
+});
+
+it('branches filter does not match non-matching branch', function () {
+    $sub = EventSubscription::fromArray(['event' => 'push', 'filters' => ['branches' => ['main']]]);
+
+    expect($sub->matches('push', null, ['branch' => 'feature/foo']))->toBeFalse();
+});
+
+it('branches filter does not match when no branch in context', function () {
+    $sub = EventSubscription::fromArray(['event' => 'push', 'filters' => ['branches' => ['main']]]);
+
+    expect($sub->matches('push', null, []))->toBeFalse();
+});
+
+it('branches filter matches any of multiple patterns', function () {
+    $sub = EventSubscription::fromArray(['event' => 'push', 'filters' => ['branches' => ['main', 'release/*']]]);
+
+    expect($sub->matches('push', null, ['branch' => 'main']))->toBeTrue()
+        ->and($sub->matches('push', null, ['branch' => 'release/v2']))->toBeTrue()
+        ->and($sub->matches('push', null, ['branch' => 'feature/x']))->toBeFalse();
+});
+
+// --- matches: combined filters (AND logic) ---
+
+it('all filters must match (AND)', function () {
+    $sub = EventSubscription::fromArray(['event' => 'pull_request.opened', 'filters' => [
+        'labels' => ['bug'],
+        'base_branch' => 'main',
+    ]]);
+
+    // Both match
+    expect($sub->matches('pull_request', 'opened', ['labels' => ['bug'], 'base_branch' => 'main']))->toBeTrue();
+
+    // Only labels match
+    expect($sub->matches('pull_request', 'opened', ['labels' => ['bug'], 'base_branch' => 'develop']))->toBeFalse();
+
+    // Only base_branch matches
+    expect($sub->matches('pull_request', 'opened', ['labels' => ['feature'], 'base_branch' => 'main']))->toBeFalse();
+});
+
+// --- matches: no filters ---
+
+it('no filters means match on event+action only', function () {
+    $sub = EventSubscription::fromArray(['event' => 'push', 'filters' => []]);
+
+    expect($sub->matches('push', null, ['branch' => 'anything']))->toBeTrue();
+});


### PR DESCRIPTION
## Summary

- Agents can now subscribe to specific event+action pairs (e.g. `issues.opened`, `pull_request.opened`) with contextual filters (labels, base branch, branch globs) instead of broad event types
- New `EventSubscription` value object handles matching logic with backward compatibility for bare event types
- Events tab UI redesigned with action-level checkboxes, filter inputs, and GitHub event key descriptions
- Data migration converts existing flat string events to subscription objects

## Test plan

- [x] `php artisan test --compact` — 243 tests passing
- [x] `vendor/bin/pint --dirty` — clean
- [ ] Manual: create agent with `issues.opened` + labels filter, verify only matching events dispatch
- [ ] Manual: existing agents with bare event types continue to work after migration
- [ ] Manual: verify events tab UI renders correctly in create/edit/show views

🤖 Generated with [Claude Code](https://claude.com/claude-code)