### PR TITLE
Fix MCP routes missing from route cache

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -10,13 +10,17 @@ return Application::configure(basePath: dirname(__DIR__))
         api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
+        then: function (): void {
+            $path = base_path('routes/ai.php');
+
+            if (file_exists($path)) {
+                Illuminate\Support\Facades\Route::group([], $path);
+            }
+        },
     )
     ->withMiddleware(function (Middleware $middleware): void {
         $middleware->validateCsrfTokens(except: [
-            'mcp/github',
-            'mcp/github/*',
-            'mcp/pageant',
-            'mcp/pageant/*',
+            'mcp/*',
             'oauth/*',
         ]);
     })


### PR DESCRIPTION
## Summary
- Register `routes/ai.php` via `withRouting(then:)` in `bootstrap/app.php` so MCP and OAuth routes are included in the route cache
- `McpServiceProvider` skips loading `ai.php` when routes are cached, so production had no MCP routes registered — causing 419 errors
- Simplified CSRF exclusions to `mcp/*` and `oauth/*`

## Test plan
- [ ] Deploy to Forge and verify MCP client can connect to `/mcp/pageant`
- [ ] Verify OAuth flow completes successfully
- [ ] Verify `php artisan route:list --path=mcp` shows routes after `php artisan optimize`

🤖 Generated with [Claude Code](https://claude.com/claude-code)