### PR TITLE
Remove broken then callback from route registration

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -10,13 +10,6 @@ return Application::configure(basePath: dirname(__DIR__))
         api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
-        then: function (): void {
-            $path = base_path('routes/ai.php');
-
-            if (file_exists($path)) {
-                Illuminate\Support\Facades\Route::group([], $path);
-            }
-        },
     )
     ->withMiddleware(function (Middleware $middleware): void {
         $middleware->validateCsrfTokens(except: [


### PR DESCRIPTION
## Summary
- Removes the `then` callback added in #14 that caused `Class "Laravel\Mcp\Facades\Mcp" not found` during `composer install`
- `McpServiceProvider` already handles loading `routes/ai.php` and includes MCP routes in the route cache — the callback was unnecessary
- CSRF exclusion simplification from #14 (`mcp/*`, `oauth/*`) is preserved

## Test plan
- [ ] Verify `composer install` completes without errors
- [ ] Verify `php artisan optimize` caches MCP routes
- [ ] Verify MCP client can connect after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)