### PR TITLE
Add global AI chat panel with streaming assistant

### DIFF
--- a/app/Ai/Agents/PageantAssistant.php
+++ b/app/Ai/Agents/PageantAssistant.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Ai\Agents;
+
+use App\Ai\ToolRegistry;
+use App\Models\User;
+use Laravel\Ai\Concerns\RemembersConversations;
+use Laravel\Ai\Contracts\Agent as AgentContract;
+use Laravel\Ai\Contracts\Conversational;
+use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Promptable;
+
+class PageantAssistant implements AgentContract, Conversational, HasTools
+{
+    use Promptable, RemembersConversations;
+
+    public function __construct(
+        protected User $user,
+        protected string $repoFullName,
+        protected string $pageContext = '',
+    ) {}
+
+    public function instructions(): string
+    {
+        return implode("\n\n", array_filter([
+            'You are a helpful Pageant assistant. Pageant is a platform for managing GitHub repositories, agents, work items, and projects.',
+            'You help users create and configure agents, work items, issues, pull requests, and other GitHub operations.',
+            "You are operating on the GitHub repository: {$this->repoFullName}.",
+            'Use the available tools to interact with the repository when the user asks you to perform actions.',
+            'Be concise and helpful in your responses.',
+            $this->pageContext ? "Current page context: {$this->pageContext}" : null,
+        ]));
+    }
+
+    public function tools(): iterable
+    {
+        return ToolRegistry::resolve(
+            array_keys(ToolRegistry::available()),
+            $this->repoFullName,
+        );
+    }
+}

--- a/app/Http/Controllers/ChatController.php
+++ b/app/Http/Controllers/ChatController.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Ai\Agents\PageantAssistant;
+use App\Models\Repo;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class ChatController extends Controller
+{
+    public function stream(Request $request)
+    {
+        $request->validate([
+            'message' => ['required', 'string', 'max:10000'],
+            'conversation_id' => ['nullable', 'string', 'max:36'],
+            'repo_full_name' => ['nullable', 'string'],
+            'page_context' => ['nullable', 'string', 'max:500'],
+        ]);
+
+        $user = $request->user();
+        $repoFullName = $request->input('repo_full_name') ?? $this->resolveDefaultRepo($user);
+
+        if (! $repoFullName) {
+            return response()->json(['error' => 'No repository available. Please add a repo first.'], 422);
+        }
+
+        $assistant = new PageantAssistant(
+            user: $user,
+            repoFullName: $repoFullName,
+            pageContext: $request->input('page_context', ''),
+        );
+
+        $assistant->forUser($user);
+
+        if ($conversationId = $request->input('conversation_id')) {
+            $assistant->continue($conversationId, $user);
+        }
+
+        return $assistant->stream($request->input('message'));
+    }
+
+    public function messages(Request $request)
+    {
+        $request->validate([
+            'conversation_id' => ['required', 'string', 'max:36'],
+        ]);
+
+        $messages = DB::table('agent_conversation_messages')
+            ->where('conversation_id', $request->input('conversation_id'))
+            ->orderBy('created_at')
+            ->get(['role', 'content']);
+
+        return response()->json($messages);
+    }
+
+    protected function resolveDefaultRepo(mixed $user): ?string
+    {
+        $organizationId = $user->currentOrganizationId();
+
+        if (! $organizationId) {
+            return null;
+        }
+
+        $repo = Repo::where('organization_id', $organizationId)
+            ->where('source', 'github')
+            ->first();
+
+        return $repo?->source_reference;
+    }
+}

--- a/resources/views/components/⚡chat-panel.blade.php
+++ b/resources/views/components/⚡chat-panel.blade.php
@@ -1,0 +1,308 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Laravel\Ai\Contracts\ConversationStore;
+use Livewire\Attributes\Computed;
+use Livewire\Component;
+
+new class extends Component
+{
+    public ?string $conversationId = null;
+
+    public array $messages = [];
+
+    public function mount(): void
+    {
+        $store = resolve(ConversationStore::class);
+        $this->conversationId = $store->latestConversationId(auth()->id());
+
+        if ($this->conversationId) {
+            $this->loadMessages();
+        }
+    }
+
+    public function loadMessages(): void
+    {
+        if (! $this->conversationId) {
+            $this->messages = [];
+
+            return;
+        }
+
+        $this->messages = DB::table('agent_conversation_messages')
+            ->where('conversation_id', $this->conversationId)
+            ->orderBy('created_at')
+            ->get(['role', 'content'])
+            ->map(fn ($m) => ['role' => $m->role, 'content' => $m->content])
+            ->all();
+    }
+
+    public function newConversation(): void
+    {
+        $this->conversationId = null;
+        $this->messages = [];
+    }
+
+    public function appendMessage(string $role, string $content): void
+    {
+        $this->messages[] = ['role' => $role, 'content' => $content];
+    }
+
+    public function setConversationId(string $id): void
+    {
+        $this->conversationId = $id;
+    }
+
+    #[Computed]
+    public function defaultRepo(): ?string
+    {
+        $user = auth()->user();
+        $organizationId = $user->currentOrganizationId();
+
+        if (! $organizationId) {
+            return null;
+        }
+
+        return \App\Models\Repo::where('organization_id', $organizationId)
+            ->where('source', 'github')
+            ->first()
+            ?->source_reference;
+    }
+};
+?>
+
+<div
+    x-data="{
+        open: false,
+        currentMessage: '',
+        streaming: false,
+        streamedContent: '',
+        messages: @entangle('messages'),
+        conversationId: @entangle('conversationId'),
+
+        toggle() {
+            this.open = ! this.open;
+            if (this.open) {
+                this.$nextTick(() => this.scrollToBottom());
+            }
+        },
+
+        scrollToBottom() {
+            const container = this.$refs.messageList;
+            if (container) {
+                container.scrollTop = container.scrollHeight;
+            }
+        },
+
+        getPageContext() {
+            const path = window.location.pathname;
+            const parts = path.split('/').filter(Boolean);
+
+            if (parts.length === 0) return 'User is on the dashboard';
+
+            const resource = parts[0];
+            const action = parts.length > 1 ? parts[parts.length - 1] : 'index';
+
+            if (action === 'create') return `User is on the ${resource} create page`;
+            if (action === 'edit') return `User is editing a ${resource.replace(/s$/, '')}`;
+            if (parts.length > 1 && action !== 'index') return `User is viewing a ${resource.replace(/s$/, '')}`;
+
+            return `User is on the ${resource} index page`;
+        },
+
+        async sendMessage() {
+            const message = this.currentMessage.trim();
+            if (! message || this.streaming) return;
+
+            this.currentMessage = '';
+            this.messages.push({ role: 'user', content: message });
+            this.streaming = true;
+            this.streamedContent = '';
+
+            this.$nextTick(() => this.scrollToBottom());
+
+            try {
+                const response = await fetch('{{ route('chat.stream') }}', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRF-TOKEN': document.querySelector('meta[name=csrf-token]')?.content || '{{ csrf_token() }}',
+                        'Accept': 'text/event-stream',
+                    },
+                    body: JSON.stringify({
+                        message: message,
+                        conversation_id: this.conversationId,
+                        repo_full_name: @js($this->defaultRepo),
+                        page_context: this.getPageContext(),
+                    }),
+                });
+
+                if (! response.ok) {
+                    const error = await response.json();
+                    this.messages.push({ role: 'assistant', content: error.error || 'An error occurred.' });
+                    this.streaming = false;
+                    return;
+                }
+
+                const reader = response.body.getReader();
+                const decoder = new TextDecoder();
+                let buffer = '';
+
+                while (true) {
+                    const { done, value } = await reader.read();
+                    if (done) break;
+
+                    buffer += decoder.decode(value, { stream: true });
+                    const lines = buffer.split('\n');
+                    buffer = lines.pop();
+
+                    for (const line of lines) {
+                        if (! line.startsWith('data: ')) continue;
+
+                        const data = line.slice(6);
+                        if (data === '[DONE]') continue;
+
+                        try {
+                            const event = JSON.parse(data);
+                            if (event.type === 'text_delta') {
+                                this.streamedContent += event.delta;
+                                this.$nextTick(() => this.scrollToBottom());
+                            }
+                            if (event.conversation_id) {
+                                this.conversationId = event.conversation_id;
+                            }
+                        } catch (e) {
+                            // Skip unparseable lines
+                        }
+                    }
+                }
+
+                if (this.streamedContent) {
+                    this.messages.push({ role: 'assistant', content: this.streamedContent });
+                    this.streamedContent = '';
+                    $wire.call('appendMessage', 'assistant', this.messages[this.messages.length - 1].content);
+                }
+            } catch (error) {
+                this.messages.push({ role: 'assistant', content: 'Failed to connect. Please try again.' });
+            } finally {
+                this.streaming = false;
+            }
+        },
+
+        newChat() {
+            $wire.call('newConversation');
+            this.messages = [];
+            this.streamedContent = '';
+        }
+    }"
+    @keydown.meta.k.window="toggle()"
+    @toggle-chat-panel.window="toggle()"
+>
+    {{-- Toggle Button (mobile only, desktop uses sidebar item) --}}
+    <button
+        @click="toggle()"
+        class="fixed bottom-6 right-6 z-40 flex h-12 w-12 items-center justify-center rounded-full bg-zinc-800 text-white shadow-lg transition hover:bg-zinc-700 dark:bg-zinc-200 dark:text-zinc-800 dark:hover:bg-zinc-300 lg:hidden"
+    >
+        <flux:icon.chat-bubble-left-right class="size-5" />
+    </button>
+
+    {{-- Slide-over Panel --}}
+    <div
+        x-show="open"
+        x-transition:enter="transition ease-out duration-200"
+        x-transition:enter-start="translate-x-full"
+        x-transition:enter-end="translate-x-0"
+        x-transition:leave="transition ease-in duration-150"
+        x-transition:leave-start="translate-x-0"
+        x-transition:leave-end="translate-x-full"
+        class="fixed inset-y-0 right-0 z-50 flex w-full max-w-md flex-col border-l border-zinc-200 bg-white shadow-xl dark:border-zinc-700 dark:bg-zinc-900"
+        @keydown.escape.window="open = false"
+    >
+        {{-- Header --}}
+        <div class="flex items-center justify-between border-b border-zinc-200 px-4 py-3 dark:border-zinc-700">
+            <flux:heading size="sm">{{ __('Assistant') }}</flux:heading>
+            <div class="flex items-center gap-2">
+                <flux:button size="xs" variant="ghost" @click="newChat()" title="New conversation">
+                    <flux:icon.plus class="size-4" />
+                </flux:button>
+                <flux:button size="xs" variant="ghost" @click="open = false">
+                    <flux:icon.x-mark class="size-4" />
+                </flux:button>
+            </div>
+        </div>
+
+        {{-- Messages --}}
+        <div x-ref="messageList" class="flex-1 space-y-4 overflow-y-auto p-4">
+            <template x-if="messages.length === 0 && !streaming">
+                <div class="flex h-full items-center justify-center">
+                    <flux:text class="text-center text-zinc-400">
+                        {{ __('Ask me anything about your repos, agents, or work items.') }}
+                    </flux:text>
+                </div>
+            </template>
+
+            <template x-for="(msg, index) in messages" :key="index">
+                <div :class="msg.role === 'user' ? 'flex justify-end' : 'flex justify-start'">
+                    <div
+                        :class="msg.role === 'user'
+                            ? 'max-w-[80%] rounded-2xl rounded-br-md bg-zinc-800 px-4 py-2 text-sm text-white dark:bg-zinc-200 dark:text-zinc-900'
+                            : 'max-w-[80%] rounded-2xl rounded-bl-md bg-zinc-100 px-4 py-2 text-sm text-zinc-900 dark:bg-zinc-800 dark:text-zinc-100'"
+                        x-text="msg.content"
+                    ></div>
+                </div>
+            </template>
+
+            {{-- Streaming indicator --}}
+            <template x-if="streaming && streamedContent">
+                <div class="flex justify-start">
+                    <div class="max-w-[80%] rounded-2xl rounded-bl-md bg-zinc-100 px-4 py-2 text-sm text-zinc-900 dark:bg-zinc-800 dark:text-zinc-100"
+                         x-text="streamedContent"></div>
+                </div>
+            </template>
+
+            <template x-if="streaming && !streamedContent">
+                <div class="flex justify-start">
+                    <div class="max-w-[80%] rounded-2xl rounded-bl-md bg-zinc-100 px-4 py-2 text-sm text-zinc-900 dark:bg-zinc-800 dark:text-zinc-100">
+                        <div class="flex items-center gap-1">
+                            <div class="h-2 w-2 animate-bounce rounded-full bg-zinc-400" style="animation-delay: 0ms"></div>
+                            <div class="h-2 w-2 animate-bounce rounded-full bg-zinc-400" style="animation-delay: 150ms"></div>
+                            <div class="h-2 w-2 animate-bounce rounded-full bg-zinc-400" style="animation-delay: 300ms"></div>
+                        </div>
+                    </div>
+                </div>
+            </template>
+        </div>
+
+        {{-- Input --}}
+        <div class="border-t border-zinc-200 p-4 dark:border-zinc-700">
+            <form @submit.prevent="sendMessage()" class="flex gap-2">
+                <flux:input
+                    x-model="currentMessage"
+                    placeholder="{{ __('Type a message...') }}"
+                    x-bind:disabled="streaming"
+                    @keydown.enter.prevent="if (!$event.shiftKey) sendMessage()"
+                    class="flex-1"
+                />
+                <flux:button type="submit" variant="primary" size="sm" x-bind:disabled="!currentMessage.trim() || streaming">
+                    <flux:icon.paper-airplane class="size-4" />
+                </flux:button>
+            </form>
+            <flux:text size="xs" class="mt-2 text-center text-zinc-400">
+                {{ __('Cmd+K to toggle') }}
+            </flux:text>
+        </div>
+    </div>
+
+    {{-- Backdrop --}}
+    <div
+        x-show="open"
+        x-transition:enter="transition ease-out duration-200"
+        x-transition:enter-start="opacity-0"
+        x-transition:enter-end="opacity-100"
+        x-transition:leave="transition ease-in duration-150"
+        x-transition:leave-start="opacity-100"
+        x-transition:leave-end="opacity-0"
+        class="fixed inset-0 z-40 bg-black/25"
+        @click="open = false"
+    ></div>
+</div>

--- a/resources/views/layouts/app/sidebar.blade.php
+++ b/resources/views/layouts/app/sidebar.blade.php
@@ -41,6 +41,10 @@
             <flux:spacer />
 
             <flux:sidebar.nav>
+                <flux:sidebar.item icon="chat-bubble-left-right" x-data @click.prevent="$dispatch('toggle-chat-panel')" class="cursor-pointer">
+                    {{ __('Assistant') }}
+                </flux:sidebar.item>
+
                 <flux:sidebar.item icon="folder-git-2" href="https://github.com/laravel/livewire-starter-kit" target="_blank">
                     {{ __('Repository') }}
                 </flux:sidebar.item>
@@ -109,6 +113,8 @@
         </flux:header>
 
         {{ $slot }}
+
+        <livewire:chat-panel />
 
         @fluxScripts
     </body>

--- a/resources/views/partials/head.blade.php
+++ b/resources/views/partials/head.blade.php
@@ -1,5 +1,6 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<meta name="csrf-token" content="{{ csrf_token() }}" />
 
 <title>
     {{ filled($title ?? null) ? $title.' - '.config('app.name', 'Laravel') : config('app.name', 'Laravel') }}

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\ChatController;
 use App\Http\Controllers\GitHubAuthController;
 use App\Http\Controllers\GitHubWebhookController;
 use Illuminate\Support\Facades\Route;
@@ -15,6 +16,9 @@ Route::post('webhooks/github', [GitHubWebhookController::class, 'handle'])
 
 Route::middleware(['auth', 'verified'])->group(function () {
     Route::livewire('dashboard', 'pages::dashboard')->name('dashboard');
+
+    Route::post('chat/stream', [ChatController::class, 'stream'])->name('chat.stream');
+    Route::get('chat/messages', [ChatController::class, 'messages'])->name('chat.messages');
 });
 
 require __DIR__.'/resources.php';

--- a/tests/Feature/ChatPanelTest.php
+++ b/tests/Feature/ChatPanelTest.php
@@ -1,0 +1,134 @@
+<?php
+
+use App\Ai\Agents\PageantAssistant;
+use App\Models\GithubInstallation;
+use App\Models\Organization;
+use App\Models\Repo;
+use App\Models\User;
+
+beforeEach(function () {
+    $this->organization = Organization::factory()->create();
+    $this->installation = GithubInstallation::factory()->create([
+        'organization_id' => $this->organization->id,
+        'installation_id' => 12345,
+    ]);
+    $this->repo = Repo::factory()->create([
+        'organization_id' => $this->organization->id,
+        'source' => 'github',
+        'source_reference' => 'acme/widgets',
+    ]);
+    $this->user = User::factory()->create([
+        'current_organization_id' => $this->organization->id,
+    ]);
+    $this->user->organizations()->attach($this->organization);
+});
+
+it('renders the chat panel for authenticated users', function () {
+    $this->actingAs($this->user)
+        ->get(route('dashboard'))
+        ->assertOk()
+        ->assertSeeHtml('toggle-chat-panel');
+});
+
+it('requires authentication for the stream endpoint', function () {
+    $this->postJson(route('chat.stream'), [
+        'message' => 'Hello',
+    ])->assertUnauthorized();
+});
+
+it('requires authentication for the messages endpoint', function () {
+    $this->getJson(route('chat.messages', ['conversation_id' => 'test-id']))
+        ->assertUnauthorized();
+});
+
+it('validates the stream request', function () {
+    $this->actingAs($this->user)
+        ->postJson(route('chat.stream'), [])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors(['message']);
+});
+
+it('validates the messages request', function () {
+    $this->actingAs($this->user)
+        ->getJson(route('chat.messages'))
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors(['conversation_id']);
+});
+
+it('returns error when no repo is available', function () {
+    $orgWithoutRepo = Organization::factory()->create();
+    $user = User::factory()->create([
+        'current_organization_id' => $orgWithoutRepo->id,
+    ]);
+    $user->organizations()->attach($orgWithoutRepo);
+
+    $this->actingAs($user)
+        ->postJson(route('chat.stream'), [
+            'message' => 'Hello',
+        ])->assertUnprocessable()
+        ->assertJson(['error' => 'No repository available. Please add a repo first.']);
+});
+
+it('streams a response via SSE', function () {
+    PageantAssistant::fake(['Hello! How can I help?']);
+
+    $response = $this->actingAs($this->user)
+        ->post(route('chat.stream'), [
+            'message' => 'Hello',
+            'repo_full_name' => 'acme/widgets',
+        ]);
+
+    $response->assertOk();
+    $response->assertHeader('content-type', 'text/event-stream; charset=utf-8');
+});
+
+it('constructs PageantAssistant with correct instructions', function () {
+    $assistant = new PageantAssistant(
+        user: $this->user,
+        repoFullName: 'acme/widgets',
+        pageContext: 'User is on the agents index page',
+    );
+
+    expect($assistant->instructions())
+        ->toContain('Pageant assistant')
+        ->toContain('acme/widgets')
+        ->toContain('User is on the agents index page');
+});
+
+it('resolves all tools for PageantAssistant', function () {
+    $assistant = new PageantAssistant(
+        user: $this->user,
+        repoFullName: 'acme/widgets',
+    );
+
+    $tools = iterator_to_array($assistant->tools());
+
+    expect($tools)->not->toBeEmpty();
+});
+
+it('returns conversation messages', function () {
+    $store = resolve(\Laravel\Ai\Contracts\ConversationStore::class);
+    $conversationId = $store->storeConversation($this->user->id, 'Test chat');
+
+    \Illuminate\Support\Facades\DB::table('agent_conversation_messages')->insert([
+        'id' => \Illuminate\Support\Str::uuid7()->toString(),
+        'conversation_id' => $conversationId,
+        'user_id' => $this->user->id,
+        'agent' => PageantAssistant::class,
+        'role' => 'user',
+        'content' => 'Hello',
+        'attachments' => '[]',
+        'tool_calls' => '[]',
+        'tool_results' => '[]',
+        'usage' => '[]',
+        'meta' => '[]',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $this->actingAs($this->user)
+        ->getJson(route('chat.messages', ['conversation_id' => $conversationId]))
+        ->assertOk()
+        ->assertJsonCount(1)
+        ->assertJsonFragment(['role' => 'user', 'content' => 'Hello']);
+});


### PR DESCRIPTION
## Summary
- Adds a collapsible right-side chat panel (`<livewire:chat-panel />`) embedded in the sidebar layout, persistent across page navigations
- New `PageantAssistant` agent with access to all Pageant tools and current page context awareness
- SSE streaming via `POST /chat/stream` with Alpine.js `fetch()` + `ReadableStream` on the frontend
- Conversation persistence via Laravel AI's `RemembersConversations` trait and `ConversationStore`

## Test plan
- [x] 10 feature tests covering auth, validation, streaming, instructions, tools, and message retrieval
- [ ] Manual: open chat panel via sidebar item or Cmd+K, send a message, verify streamed response
- [ ] Manual: navigate to different page, reopen panel — conversation history persists
- [ ] Manual: verify "New conversation" button clears history
- [ ] Manual: verify error shown when no repo is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)