### PR TITLE
Fix MCP OAuth authorize page dark mode visibility

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -26,6 +26,18 @@
     --color-accent: var(--color-neutral-800);
     --color-accent-content: var(--color-neutral-800);
     --color-accent-foreground: var(--color-white);
+
+    --color-background: var(--background);
+    --color-foreground: var(--foreground);
+    --color-card: var(--card);
+    --color-card-foreground: var(--card-foreground);
+    --color-primary: var(--primary);
+    --color-primary-foreground: var(--primary-foreground);
+    --color-muted: var(--muted);
+    --color-muted-foreground: var(--muted-foreground);
+    --color-border: var(--border);
+    --color-input: var(--input);
+    --color-ring: var(--ring);
 }
 
 @layer theme {
@@ -37,6 +49,34 @@
 }
 
 @layer base {
+
+    :root {
+        --background: oklch(1 0 0);
+        --foreground: oklch(0.145 0 0);
+        --card: oklch(1 0 0);
+        --card-foreground: oklch(0.145 0 0);
+        --primary: oklch(0.205 0 0);
+        --primary-foreground: oklch(0.985 0 0);
+        --muted: oklch(0.97 0 0);
+        --muted-foreground: oklch(0.556 0 0);
+        --border: oklch(0.922 0 0);
+        --input: oklch(0.922 0 0);
+        --ring: oklch(0.708 0 0);
+    }
+
+    .dark {
+        --background: oklch(0.145 0 0);
+        --foreground: oklch(0.985 0 0);
+        --card: oklch(0.145 0 0);
+        --card-foreground: oklch(0.985 0 0);
+        --primary: oklch(0.985 0 0);
+        --primary-foreground: oklch(0.205 0 0);
+        --muted: oklch(0.269 0 0);
+        --muted-foreground: oklch(0.708 0 0);
+        --border: oklch(0.269 0 0);
+        --input: oklch(0.269 0 0);
+        --ring: oklch(0.556 0 0);
+    }
 
     *,
     ::after,


### PR DESCRIPTION
## Summary
- Define missing CSS color tokens (background, foreground, card, primary, muted, border, input, ring) for both light and dark modes
- The MCP OAuth authorize page used shadcn-style utility classes but the tokens were never defined, making all text invisible in dark mode

## Test plan
- [ ] Visit the MCP OAuth authorize page with dark mode enabled and verify text is visible
- [ ] Verify the page still renders correctly in light mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)