### PR TITLE
Add check all / uncheck all to Pageant Tools tab

### DIFF
--- a/app/Ai/ToolRegistry.php
+++ b/app/Ai/ToolRegistry.php
@@ -194,6 +194,28 @@ class ToolRegistry
     }
 
     /**
+     * @return list<string>
+     */
+    public static function githubToolNames(): array
+    {
+        return array_keys(array_filter(
+            self::TOOL_MAP,
+            fn (array $entry) => empty($entry['local']) && ($entry['category'] ?? null) !== 'pageant',
+        ));
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function pageantToolNames(): array
+    {
+        return array_keys(array_filter(
+            self::TOOL_MAP,
+            fn (array $entry) => ! empty($entry['local']) || ($entry['category'] ?? null) === 'pageant',
+        ));
+    }
+
+    /**
      * @return array<string, array<string, string>>
      */
     public static function grouped(): array

--- a/resources/views/pages/agents/⚡create.blade.php
+++ b/resources/views/pages/agents/⚡create.blade.php
@@ -82,12 +82,22 @@ new #[Title('Create Agent')] class extends Component {
 
     public function selectAllTools(): void
     {
-        $this->selectedTools = array_keys(ToolRegistry::available());
+        $this->selectedTools = array_values(array_unique(array_merge($this->selectedTools, ToolRegistry::githubToolNames())));
     }
 
     public function deselectAllTools(): void
     {
-        $this->selectedTools = [];
+        $this->selectedTools = array_values(array_diff($this->selectedTools, ToolRegistry::githubToolNames()));
+    }
+
+    public function selectAllPageantTools(): void
+    {
+        $this->selectedTools = array_values(array_unique(array_merge($this->selectedTools, ToolRegistry::pageantToolNames())));
+    }
+
+    public function deselectAllPageantTools(): void
+    {
+        $this->selectedTools = array_values(array_diff($this->selectedTools, ToolRegistry::pageantToolNames()));
     }
 
     public function selectAllEvents(): void
@@ -352,6 +362,10 @@ new #[Title('Create Agent')] class extends Component {
                 {{-- Pageant Tools tab --}}
                 <div x-show="tab === 'pageant-tools'" x-cloak>
                     <div class="space-y-4">
+                        <div class="flex items-center gap-2">
+                            <flux:button size="xs" wire:click="selectAllPageantTools">{{ __('Check all') }}</flux:button>
+                            <flux:button size="xs" wire:click="deselectAllPageantTools">{{ __('Uncheck all') }}</flux:button>
+                        </div>
                         <flux:checkbox.group wire:model="selectedTools">
                             @foreach ($this->toolCategories['pageant'] as $group => $tools)
                                 <div class="mb-4">

--- a/resources/views/pages/agents/⚡edit.blade.php
+++ b/resources/views/pages/agents/⚡edit.blade.php
@@ -154,12 +154,22 @@ new #[Title('Edit Agent')] class extends Component {
 
     public function selectAllTools(): void
     {
-        $this->selectedTools = array_keys(ToolRegistry::available());
+        $this->selectedTools = array_values(array_unique(array_merge($this->selectedTools, ToolRegistry::githubToolNames())));
     }
 
     public function deselectAllTools(): void
     {
-        $this->selectedTools = [];
+        $this->selectedTools = array_values(array_diff($this->selectedTools, ToolRegistry::githubToolNames()));
+    }
+
+    public function selectAllPageantTools(): void
+    {
+        $this->selectedTools = array_values(array_unique(array_merge($this->selectedTools, ToolRegistry::pageantToolNames())));
+    }
+
+    public function deselectAllPageantTools(): void
+    {
+        $this->selectedTools = array_values(array_diff($this->selectedTools, ToolRegistry::pageantToolNames()));
     }
 
     public function selectAllEvents(): void
@@ -420,6 +430,10 @@ new #[Title('Edit Agent')] class extends Component {
                 {{-- Pageant Tools tab --}}
                 <div x-show="tab === 'pageant-tools'" x-cloak>
                     <div class="space-y-4">
+                        <div class="flex items-center gap-2">
+                            <flux:button size="xs" wire:click="selectAllPageantTools">{{ __('Check all') }}</flux:button>
+                            <flux:button size="xs" wire:click="deselectAllPageantTools">{{ __('Uncheck all') }}</flux:button>
+                        </div>
                         <flux:checkbox.group wire:model="selectedTools">
                             @foreach ($this->toolCategories['pageant'] as $group => $tools)
                                 <div class="mb-4">


### PR DESCRIPTION
## Summary
- Add "Check all" and "Uncheck all" buttons to the Pageant Tools tab
- Fix GitHub Tools tab buttons to only affect GitHub tools (not all tools)
- Each tab's buttons now preserve selections on the other tab
- Add `githubToolNames()` and `pageantToolNames()` helpers to ToolRegistry

## Test plan
- [ ] Pageant Tools tab has check all / uncheck all buttons
- [ ] Checking all on GitHub Tools tab doesn't affect Pageant tools selections
- [ ] Checking all on Pageant Tools tab doesn't affect GitHub tools selections
- [ ] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)