### PR TITLE
Fix duplicate assistant responses in chat panel

### DIFF
--- a/resources/views/components/⚡chat-panel.blade.php
+++ b/resources/views/components/⚡chat-panel.blade.php
@@ -42,15 +42,6 @@ new class extends Component
         $this->messages = [];
     }
 
-    public function appendMessage(string $role, string $content): void
-    {
-        $this->messages[] = ['role' => $role, 'content' => $content];
-    }
-
-    public function setConversationId(string $id): void
-    {
-        $this->conversationId = $id;
-    }
 
 };
 ?>
@@ -164,7 +155,6 @@ new class extends Component
                 if (this.streamedContent) {
                     this.messages.push({ role: 'assistant', content: this.streamedContent });
                     this.streamedContent = '';
-                    $wire.call('appendMessage', 'assistant', this.messages[this.messages.length - 1].content);
                 }
             } catch (error) {
                 this.messages.push({ role: 'assistant', content: 'Failed to connect. Please try again.' });


### PR DESCRIPTION
## Summary
- Remove redundant `$wire.call('appendMessage', ...)` that was adding the assistant message a second time — `@entangle('messages')` already syncs Alpine array mutations to Livewire
- Remove unused `appendMessage` and `setConversationId` Livewire methods

## Test plan
- [ ] Open the assistant panel, send a message, verify only one response bubble appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)