### PR TITLE
Refine assistant prompts for better guidance and tone

### DIFF
--- a/app/Ai/Agents/PageantAssistant.php
+++ b/app/Ai/Agents/PageantAssistant.php
@@ -24,14 +24,11 @@ class PageantAssistant implements AgentContract, Conversational, HasTools
     {
         return implode("\n\n", array_filter([
             'You are a helpful Pageant assistant. Pageant is a platform for managing GitHub repositories, agents, work items, and projects.',
-            'You help users create and configure agents, work items, issues, pull requests, and other GitHub operations.',
+            'You help users manage agents, work items, issues, pull requests, and other GitHub operations.',
             $this->repoFullName
-                ? "You are operating on the GitHub repository: {$this->repoFullName}."
-                : 'No repository is currently selected. You can list repos and projects, but GitHub-specific tools are unavailable until a repo is selected.',
-            $this->repoFullName
-                ? 'Use the available tools to interact with the repository when the user asks you to perform actions.'
-                : null,
-            'Be concise and helpful in your responses.',
+                ? "You are operating on the GitHub repository: {$this->repoFullName}. Use the available tools to interact with the repository when the user asks you to perform actions."
+                : 'No repository is currently selected. You have tools to list repos and manage projects. If the user wants to perform GitHub operations (issues, PRs, etc.), use the list_repos tool to show available repos and ask which one to use.',
+            'Be concise. Do not use emojis. Give short, direct answers.',
             $this->pageContext ? "Current page context: {$this->pageContext}" : null,
         ]));
     }


### PR DESCRIPTION
## Summary
- When no repo is selected, the assistant now offers to list repos and ask which one to use, instead of telling users that GitHub tools are "unavailable" and to navigate elsewhere
- Added explicit "no emojis" and "concise answers" instructions to fix verbose, emoji-heavy responses
- Consolidated duplicated repo-conditional prompt blocks

## Test plan
- [ ] Open the assistant with no repo context, ask to create an issue — verify it offers to list repos instead of refusing
- [ ] Verify responses are concise and emoji-free

🤖 Generated with [Claude Code](https://claude.com/claude-code)