### PR TITLE
Render assistant chat messages with Markdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
                 "autoprefixer": "^10.4.20",
                 "axios": "^1.7.4",
                 "concurrently": "^9.0.1",
+                "dompurify": "^3.3.2",
                 "laravel-vite-plugin": "^2.0",
+                "marked": "^17.0.4",
                 "tailwindcss": "^4.0.7",
                 "vite": "^7.0.4"
             },
@@ -1068,6 +1070,13 @@
             "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
             "license": "MIT"
         },
+        "node_modules/@types/trusted-types": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+            "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+            "license": "MIT",
+            "optional": true
+        },
         "node_modules/ansi-regex": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -1335,6 +1344,18 @@
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/dompurify": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.2.tgz",
+            "integrity": "sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ==",
+            "license": "(MPL-2.0 OR Apache-2.0)",
+            "engines": {
+                "node": ">=20"
+            },
+            "optionalDependencies": {
+                "@types/trusted-types": "^2.0.7"
             }
         },
         "node_modules/dunder-proto": {
@@ -1965,6 +1986,18 @@
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.5"
+            }
+        },
+        "node_modules/marked": {
+            "version": "17.0.4",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.4.tgz",
+            "integrity": "sha512-NOmVMM+KAokHMvjWmC5N/ZOvgmSWuqJB8FoYI019j4ogb/PeRMKoKIjReZ2w3376kkA8dSJIP8uD993Kxc0iRQ==",
+            "license": "MIT",
+            "bin": {
+                "marked": "bin/marked.js"
+            },
+            "engines": {
+                "node": ">= 20"
             }
         },
         "node_modules/math-intrinsics": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
         "autoprefixer": "^10.4.20",
         "axios": "^1.7.4",
         "concurrently": "^9.0.1",
+        "dompurify": "^3.3.2",
         "laravel-vite-plugin": "^2.0",
+        "marked": "^17.0.4",
         "tailwindcss": "^4.0.7",
         "vite": "^7.0.4"
     },

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -104,3 +104,54 @@ select:focus[data-flux-control] {
 /* \[:where(&)\]:size-4 {
     @apply size-4;
 } */
+
+.chat-markdown p {
+    @apply my-1 first:mt-0 last:mb-0;
+}
+
+.chat-markdown ul,
+.chat-markdown ol {
+    @apply my-1 ml-4 first:mt-0 last:mb-0;
+}
+
+.chat-markdown ul {
+    @apply list-disc;
+}
+
+.chat-markdown ol {
+    @apply list-decimal;
+}
+
+.chat-markdown li {
+    @apply my-0.5;
+}
+
+.chat-markdown strong {
+    @apply font-semibold;
+}
+
+.chat-markdown code {
+    @apply rounded bg-black/10 px-1 py-0.5 text-xs dark:bg-white/10;
+}
+
+.chat-markdown pre {
+    @apply my-1 overflow-x-auto rounded bg-black/10 p-2 text-xs first:mt-0 last:mb-0 dark:bg-white/10;
+}
+
+.chat-markdown pre code {
+    @apply bg-transparent p-0;
+}
+
+.chat-markdown a {
+    @apply underline;
+}
+
+.chat-markdown h1,
+.chat-markdown h2,
+.chat-markdown h3 {
+    @apply my-1 font-semibold first:mt-0;
+}
+
+.chat-markdown blockquote {
+    @apply my-1 border-l-2 border-current/20 pl-3 italic first:mt-0 last:mb-0;
+}

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,0 +1,9 @@
+import { marked } from 'marked';
+import DOMPurify from 'dompurify';
+
+marked.setOptions({
+    breaks: true,
+    gfm: true,
+});
+
+window.renderMarkdown = (text) => DOMPurify.sanitize(marked.parse(text));

--- a/resources/views/components/⚡chat-panel.blade.php
+++ b/resources/views/components/⚡chat-panel.blade.php
@@ -221,8 +221,8 @@ new class extends Component
                     <div
                         :class="msg.role === 'user'
                             ? 'max-w-[80%] rounded-2xl rounded-br-md bg-zinc-800 px-4 py-2 text-sm text-white dark:bg-zinc-200 dark:text-zinc-900'
-                            : 'max-w-[80%] rounded-2xl rounded-bl-md bg-zinc-100 px-4 py-2 text-sm text-zinc-900 dark:bg-zinc-800 dark:text-zinc-100'"
-                        x-text="msg.content"
+                            : 'chat-markdown max-w-[80%] rounded-2xl rounded-bl-md bg-zinc-100 px-4 py-2 text-sm text-zinc-900 dark:bg-zinc-800 dark:text-zinc-100'"
+                        x-html="msg.role === 'user' ? msg.content : window.renderMarkdown(msg.content)"
                     ></div>
                 </div>
             </template>
@@ -230,8 +230,8 @@ new class extends Component
             {{-- Streaming indicator --}}
             <template x-if="streaming && streamedContent">
                 <div class="flex justify-start">
-                    <div class="max-w-[80%] rounded-2xl rounded-bl-md bg-zinc-100 px-4 py-2 text-sm text-zinc-900 dark:bg-zinc-800 dark:text-zinc-100"
-                         x-text="streamedContent"></div>
+                    <div class="chat-markdown max-w-[80%] rounded-2xl rounded-bl-md bg-zinc-100 px-4 py-2 text-sm text-zinc-900 dark:bg-zinc-800 dark:text-zinc-100"
+                         x-html="window.renderMarkdown(streamedContent)"></div>
                 </div>
             </template>
 


### PR DESCRIPTION
## Summary
- Add `marked` and `dompurify` npm packages to parse and sanitize Markdown in assistant responses
- Assistant messages render bold, lists, code blocks, links, headings, and blockquotes
- User messages remain plain text
- Add `.chat-markdown` CSS styles for proper typography inside chat bubbles
- Streaming content also renders as Markdown in real-time

## Test plan
- [ ] Send a message that triggers a Markdown response (bold, lists, code) — verify it renders correctly
- [ ] Verify user messages still display as plain text
- [ ] Verify streaming content renders Markdown progressively
- [ ] Run `npm run build` — confirm clean build with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)