### PR TITLE
Make create/update issue AI tools work without pre-selected repo

### DIFF
--- a/app/Ai/ToolRegistry.php
+++ b/app/Ai/ToolRegistry.php
@@ -61,8 +61,8 @@ class ToolRegistry
         // Issues
         'get_issue' => ['class' => GetIssueTool::class, 'description' => 'Get an issue by number', 'group' => 'Issues'],
         'list_issues' => ['class' => ListIssuesTool::class, 'description' => 'List open issues', 'group' => 'Issues'],
-        'create_issue' => ['class' => CreateIssueTool::class, 'description' => 'Create a new issue', 'group' => 'Issues'],
-        'update_issue' => ['class' => UpdateIssueTool::class, 'description' => 'Update an issue', 'group' => 'Issues'],
+        'create_issue' => ['class' => CreateIssueTool::class, 'description' => 'Create a new issue', 'group' => 'Issues', 'flexible' => true],
+        'update_issue' => ['class' => UpdateIssueTool::class, 'description' => 'Update an issue', 'group' => 'Issues', 'flexible' => true],
         'close_issue' => ['class' => CloseIssueTool::class, 'description' => 'Close an issue', 'group' => 'Issues'],
         'search_issues' => ['class' => SearchIssuesTool::class, 'description' => 'Search issues and PRs', 'group' => 'Issues'],
 
@@ -165,6 +165,12 @@ class ToolRegistry
                 if ($user) {
                     $tools[] = new ($entry['class'])($user);
                 }
+            } elseif (! empty($entry['flexible'])) {
+                $tools[] = new ($entry['class'])(
+                    $github ?? app(GitHubService::class),
+                    $installation,
+                    $repoFullName,
+                );
             } elseif ($github && $installation && $repoFullName) {
                 $tools[] = new ($entry['class'])($github, $installation, $repoFullName);
             }
@@ -180,7 +186,9 @@ class ToolRegistry
     {
         return array_filter(
             self::available(),
-            fn (string $description, string $name) => ! empty(self::TOOL_MAP[$name]['local']) || $repoFullName !== null,
+            fn (string $description, string $name) => ! empty(self::TOOL_MAP[$name]['local'])
+                || ! empty(self::TOOL_MAP[$name]['flexible'])
+                || $repoFullName !== null,
             ARRAY_FILTER_USE_BOTH,
         );
     }

--- a/app/Ai/Tools/CreateIssueTool.php
+++ b/app/Ai/Tools/CreateIssueTool.php
@@ -3,6 +3,7 @@
 namespace App\Ai\Tools;
 
 use App\Models\GithubInstallation;
+use App\Models\Repo;
 use App\Services\GitHubService;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Ai\Contracts\Tool;
@@ -12,8 +13,8 @@ class CreateIssueTool implements Tool
 {
     public function __construct(
         protected GitHubService $github,
-        protected GithubInstallation $installation,
-        protected string $repoFullName,
+        protected ?GithubInstallation $installation = null,
+        protected ?string $repoFullName = null,
     ) {}
 
     public function description(): string
@@ -23,22 +24,38 @@ class CreateIssueTool implements Tool
 
     public function handle(Request $request): string
     {
+        $repoFullName = $this->repoFullName ?? $request['repo'];
+        $installation = $this->installation;
+
+        if (! $installation) {
+            $repo = Repo::where('source', 'github')->where('source_reference', $repoFullName)->firstOrFail();
+            $installation = GithubInstallation::where('organization_id', $repo->organization_id)->firstOrFail();
+        }
+
         $data = ['title' => $request['title']];
 
-        foreach (['body', 'labels', 'assignees'] as $field) {
+        foreach (['body', 'labels', 'assignees', 'milestone'] as $field) {
             if (isset($request[$field])) {
                 $data[$field] = $request[$field];
             }
         }
 
-        $issue = $this->github->createIssue($this->installation, $this->repoFullName, $data);
+        $issue = $this->github->createIssue($installation, $repoFullName, $data);
 
         return json_encode($issue, JSON_PRETTY_PRINT);
     }
 
     public function schema(JsonSchema $schema): array
     {
-        return [
+        $fields = [];
+
+        if (! $this->repoFullName) {
+            $fields['repo'] = $schema->string()
+                ->description('The repository in owner/repo format.')
+                ->required();
+        }
+
+        return array_merge($fields, [
             'title' => $schema->string()
                 ->description('The issue title.')
                 ->required(),
@@ -50,6 +67,8 @@ class CreateIssueTool implements Tool
             'assignees' => $schema->array()
                 ->items($schema->string())
                 ->description('GitHub usernames to assign to the issue.'),
-        ];
+            'milestone' => $schema->integer()
+                ->description('Milestone number to associate with the issue.'),
+        ]);
     }
 }

--- a/app/Ai/Tools/UpdateIssueTool.php
+++ b/app/Ai/Tools/UpdateIssueTool.php
@@ -3,6 +3,7 @@
 namespace App\Ai\Tools;
 
 use App\Models\GithubInstallation;
+use App\Models\Repo;
 use App\Services\GitHubService;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Ai\Contracts\Tool;
@@ -12,8 +13,8 @@ class UpdateIssueTool implements Tool
 {
     public function __construct(
         protected GitHubService $github,
-        protected GithubInstallation $installation,
-        protected string $repoFullName,
+        protected ?GithubInstallation $installation = null,
+        protected ?string $repoFullName = null,
     ) {}
 
     public function description(): string
@@ -23,6 +24,14 @@ class UpdateIssueTool implements Tool
 
     public function handle(Request $request): string
     {
+        $repoFullName = $this->repoFullName ?? $request['repo'];
+        $installation = $this->installation;
+
+        if (! $installation) {
+            $repo = Repo::where('source', 'github')->where('source_reference', $repoFullName)->firstOrFail();
+            $installation = GithubInstallation::where('organization_id', $repo->organization_id)->firstOrFail();
+        }
+
         $data = [];
 
         foreach (['title', 'body', 'state', 'state_reason', 'labels', 'assignees', 'milestone'] as $field) {
@@ -32,8 +41,8 @@ class UpdateIssueTool implements Tool
         }
 
         $issue = $this->github->updateIssue(
-            $this->installation,
-            $this->repoFullName,
+            $installation,
+            $repoFullName,
             (int) $request['issue_number'],
             $data,
         );
@@ -43,7 +52,15 @@ class UpdateIssueTool implements Tool
 
     public function schema(JsonSchema $schema): array
     {
-        return [
+        $fields = [];
+
+        if (! $this->repoFullName) {
+            $fields['repo'] = $schema->string()
+                ->description('The repository in owner/repo format.')
+                ->required();
+        }
+
+        return array_merge($fields, [
             'issue_number' => $schema->integer()
                 ->description('The issue number to update.')
                 ->required(),
@@ -65,6 +82,6 @@ class UpdateIssueTool implements Tool
                 ->description('Replace all assignees with these GitHub usernames.'),
             'milestone' => $schema->integer()
                 ->description('Milestone number to associate with the issue.'),
-        ];
+        ]);
     }
 }


### PR DESCRIPTION
## Summary
- Modify AI `CreateIssueTool` and `UpdateIssueTool` to accept an optional `repo` parameter and resolve the GitHub installation dynamically at call time
- When a repo is pre-selected, they behave as before (no `repo` param in schema)
- When no repo is pre-selected, they expose a required `repo` param so the assistant can use `list_repos` then call `create_issue` with the user's chosen repo
- Add `'flexible' => true` flag in `ToolRegistry` so these tools are available in `availableForContext()` even without a pre-selected repo

## Test plan
- [ ] Open assistant with no repo context, ask to create an issue — verify it lists repos, asks which one, then creates the issue
- [ ] Open assistant with a pre-selected repo — verify create/update issue still works without requiring a `repo` param

🤖 Generated with [Claude Code](https://claude.com/claude-code)