### PR TITLE
Reorder fields on work item detail page

### DIFF
--- a/resources/views/pages/work-items/⚡show.blade.php
+++ b/resources/views/pages/work-items/⚡show.blade.php
@@ -143,13 +143,13 @@ new #[Title('Work Item')] class extends Component {
             </div>
 
             <div>
-                <flux:label>{{ __('Source') }}</flux:label>
-                <flux:text>{{ $workItem->source }}</flux:text>
+                <flux:label>{{ __('Board ID') }}</flux:label>
+                <flux:text>{{ $workItem->board_id ?: '—' }}</flux:text>
             </div>
 
             <div>
-                <flux:label>{{ __('Board ID') }}</flux:label>
-                <flux:text>{{ $workItem->board_id ?: '—' }}</flux:text>
+                <flux:label>{{ __('Source') }}</flux:label>
+                <flux:text>{{ $workItem->source }}</flux:text>
             </div>
 
             <div>


### PR DESCRIPTION
Closes #61

## Summary
- Reorders fields on the work item detail page so `board_id` appears in a more logical position among the other metadata fields

## Verification
- Navigate to any work item's detail page
- Verify the board field appears in a logical position (grouped with related metadata)

🤖 Generated with [Claude Code](https://claude.com/claude-code)