### PR TITLE
Keep focus on chat input after sending

### DIFF
--- a/resources/views/components/⚡chat-panel.blade.php
+++ b/resources/views/components/⚡chat-panel.blade.php
@@ -128,7 +128,12 @@ new class extends Component
             this.streaming = true;
             this.streamedContent = '';
 
-            this.$nextTick(() => this.scrollToBottom());
+            this.$nextTick(() => {
+                this.scrollToBottom();
+                const ref = this.$refs.chatInput;
+                const input = ref?.tagName === 'INPUT' ? ref : ref?.querySelector('input');
+                input?.focus();
+            });
 
             try {
                 const response = await fetch('{{ route('chat.stream') }}', {
@@ -193,6 +198,11 @@ new class extends Component
                 this.messages.push({ role: 'assistant', content: 'Failed to connect. Please try again.' });
             } finally {
                 this.streaming = false;
+                this.$nextTick(() => {
+                    const ref = this.$refs.chatInput;
+                    const input = ref?.tagName === 'INPUT' ? ref : ref?.querySelector('input');
+                    input?.focus();
+                });
             }
         },
 
@@ -321,6 +331,7 @@ new class extends Component
     <div class="border-t border-zinc-200 p-4 dark:border-zinc-700">
         <form @submit.prevent="sendMessage()" class="flex gap-2">
             <flux:input
+                x-ref="chatInput"
                 x-model="currentMessage"
                 placeholder="{{ __('Type a message...') }}"
                 x-bind:disabled="streaming"


### PR DESCRIPTION
Closes #59

## Summary
- Maintains focus on the chat input field after a message is submitted, so the user can immediately type a follow-up

## Verification
- Open a chat in the chat panel
- Type a message and send it
- Verify the cursor remains in the input field without needing to click it again

🤖 Generated with [Claude Code](https://claude.com/claude-code)