### PR TITLE
Make assistant act proactively on clear intent

### DIFF
--- a/app/Ai/Agents/PageantAssistant.php
+++ b/app/Ai/Agents/PageantAssistant.php
@@ -30,9 +30,10 @@ class PageantAssistant implements AgentContract, Conversational, HasTools
                 : 'No repository is currently selected. You have tools to list repos and manage projects. If the user wants to perform GitHub operations (issues, PRs, etc.), use the list_repos tool to show available repos and ask which one to use.',
             'Be concise. Do not use emojis. Give short, direct answers.',
             'Act immediately when the user\'s intent is clear — do not ask for confirmation on obvious next steps. For example, if the user says "create an issue for X", create it directly without asking "are you sure?".',
-            'Batch related operations together. For example, when creating issues, also create corresponding work items without asking. When setting up a project, perform all logical setup steps in sequence.',
-            'When context narrows to a single option (one repo, one agent, one project, etc.), use it without asking the user to confirm the selection.',
-            'Only ask clarifying questions when there is genuine ambiguity that cannot be resolved from context, such as multiple equally valid interpretations of the request.',
+            'Exception: For any destructive or irreversible action (such as deleting repositories, projects, work items, or labels, performing force pushes, or merging branches/PRs), always require an explicit user instruction or confirmation before invoking the corresponding tools, even if it seems like an obvious next step.',
+            'Batch related operations together. For example, when creating issues, also create corresponding work items without asking. When setting up a project, perform all logical setup steps in sequence, as long as they are non-destructive.',
+            'When context narrows to a single option (one repo, one agent, one project, etc.), use it without asking the user to confirm the selection, except when choosing would immediately lead to a destructive or irreversible action.',
+            'Only ask clarifying questions when there is genuine ambiguity that cannot be resolved from context, or when the user appears to be requesting a destructive or irreversible action and you do not yet have explicit confirmation.',
             $this->pageContext ? "Current page context: {$this->pageContext}" : null,
         ]));
     }

--- a/tests/Feature/ChatPanelTest.php
+++ b/tests/Feature/ChatPanelTest.php
@@ -109,6 +109,7 @@ it('includes proactive behavior directives in instructions', function () {
 
     expect($instructions)
         ->toContain('Act immediately when the user\'s intent is clear')
+        ->toContain('destructive or irreversible action')
         ->toContain('Batch related operations together')
         ->toContain('context narrows to a single option')
         ->toContain('genuine ambiguity');


### PR DESCRIPTION
Closes #69

## Summary
- Updates PageantAssistant instructions to act immediately when user intent is clear instead of asking for confirmation
- Adds directives for batching related operations, using single-option contexts without asking, and only asking when there's genuine ambiguity
- Adds test verifying the new proactive behavior directives are present in instructions

## Verification
- Interact with the assistant in scenarios where intent is obvious (e.g., single repo, sequential operations)
- Verify it acts without unnecessary confirmation prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)