### PR TITLE
fix: replace 'Laravel Starter Kit' with 'Pageant' in sidebar

### DIFF
--- a/resources/views/components/app-logo.blade.php
+++ b/resources/views/components/app-logo.blade.php
@@ -3,13 +3,13 @@
 ])
 
 @if($sidebar)
-    <flux:sidebar.brand name="Laravel Starter Kit" {{ $attributes }}>
+    <flux:sidebar.brand name="Pageant" {{ $attributes }}>
         <x-slot name="logo" class="flex aspect-square size-8 items-center justify-center rounded-md bg-accent-content text-accent-foreground">
             <x-app-logo-icon class="size-5 fill-current text-white dark:text-black" />
         </x-slot>
     </flux:sidebar.brand>
 @else
-    <flux:brand name="Laravel Starter Kit" {{ $attributes }}>
+    <flux:brand name="Pageant" {{ $attributes }}>
         <x-slot name="logo" class="flex aspect-square size-8 items-center justify-center rounded-md bg-accent-content text-accent-foreground">
             <x-app-logo-icon class="size-5 fill-current text-white dark:text-black" />
         </x-slot>

--- a/tests/Feature/AppLogoTest.php
+++ b/tests/Feature/AppLogoTest.php
@@ -1,0 +1,13 @@
+<?php
+
+use App\Models\User;
+
+test('sidebar brand displays Pageant instead of Laravel Starter Kit', function () {
+    $user = User::factory()->create();
+
+    $response = $this->actingAs($user)->get(route('dashboard'));
+
+    $response->assertOk();
+    $response->assertSee('Pageant');
+    $response->assertDontSee('Laravel Starter Kit');
+});


### PR DESCRIPTION
## Summary
- Replaced "Laravel Starter Kit" with "Pageant" in the sidebar brand and header brand components (`app-logo.blade.php`)
- Added test to verify the branding displays correctly

Closes #104

## Test plan
- [x] Verify `assertSee('Pageant')` passes on the dashboard
- [x] Verify `assertDontSee('Laravel Starter Kit')` passes on the dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)