### PR TITLE
fix: rename 'Add Repos' button to 'Import Repo'

### DIFF
--- a/resources/views/pages/repos/⚡index.blade.php
+++ b/resources/views/pages/repos/⚡index.blade.php
@@ -161,7 +161,7 @@ new #[Title('Repos')] class extends Component {
         <div class="flex items-center justify-between">
             <flux:heading size="xl">{{ __('Repos') }}</flux:heading>
             <flux:button variant="primary" wire:click="openImportModal">
-                {{ __('Add Repos') }}
+                {{ __('Import Repo') }}
             </flux:button>
         </div>
 
@@ -236,7 +236,7 @@ new #[Title('Repos')] class extends Component {
 
     <flux:modal wire:model="showImportModal" variant="flyout" class="w-[32rem]">
         <div class="space-y-6">
-            <flux:heading size="lg">{{ __('Add Repos from GitHub') }}</flux:heading>
+            <flux:heading size="lg">{{ __('Import Repo from GitHub') }}</flux:heading>
 
             @if ($this->installations->isEmpty())
                 <flux:text>{{ __('No GitHub App installations found. Install the GitHub App on your account or organization first.') }}</flux:text>


### PR DESCRIPTION
Closes #113

## Summary

Renames the "Add Repos" button on the Repos index page to "Import Repo" (singular) to match the single-action pattern. Also updates the modal heading from "Add Repos from GitHub" to "Import Repo from GitHub" for consistency.

## Verification

1. Navigate to the Repos index page
2. Verify the primary button reads "Import Repo" (not "Add Repos")
3. Click the button and verify the flyout modal heading reads "Import Repo from GitHub"