### PR TITLE
Fix: hide empty fields on work item detail page

### DIFF
--- a/resources/views/pages/work-items/⚡show.blade.php
+++ b/resources/views/pages/work-items/⚡show.blade.php
@@ -127,58 +127,55 @@ new #[Title('Work Item')] class extends Component {
             </div>
         </div>
 
-        <div class="max-w-xl space-y-4">
-            <div>
-                <flux:label>{{ __('Title') }}</flux:label>
-                <flux:text>{{ $workItem->title }}</flux:text>
-            </div>
-
+        @if ($workItem->description)
             <div>
                 <flux:label>{{ __('Description') }}</flux:label>
-                <flux:text>{{ $workItem->description ?: '—' }}</flux:text>
+                <flux:text>{{ $workItem->description }}</flux:text>
             </div>
+        @endif
 
+        <div class="max-w-xl grid grid-cols-1 sm:grid-cols-2 gap-4">
             <div>
                 <flux:label>{{ __('Organization') }}</flux:label>
                 <flux:text>{{ $workItem->organization->name }}</flux:text>
             </div>
 
-            <div>
-                <flux:label>{{ __('Project') }}</flux:label>
-                @if ($workItem->project)
+            @if ($workItem->project)
+                <div>
+                    <flux:label>{{ __('Project') }}</flux:label>
                     <flux:link href="{{ route('projects.show', $workItem->project) }}" wire:navigate>
                         {{ $workItem->project->name }}
                     </flux:link>
-                @else
-                    <flux:text>{{ __('—') }}</flux:text>
-                @endif
-            </div>
+                </div>
+            @endif
 
-            <div>
-                <flux:label>{{ __('Board ID') }}</flux:label>
-                <flux:text>{{ $workItem->board_id ?: '—' }}</flux:text>
-            </div>
+            @if ($workItem->board_id)
+                <div>
+                    <flux:label>{{ __('Board ID') }}</flux:label>
+                    <flux:text>{{ $workItem->board_id }}</flux:text>
+                </div>
+            @endif
 
             <div>
                 <flux:label>{{ __('Source') }}</flux:label>
                 <flux:text>{{ $workItem->source }}</flux:text>
             </div>
 
-            <div>
-                <flux:label>{{ __('Source Reference') }}</flux:label>
-                <flux:text>{{ $workItem->source_reference ?: '—' }}</flux:text>
-            </div>
+            @if ($workItem->source_reference)
+                <div>
+                    <flux:label>{{ __('Source Reference') }}</flux:label>
+                    <flux:text>{{ $workItem->source_reference }}</flux:text>
+                </div>
+            @endif
 
-            <div>
-                <flux:label>{{ __('Source URL') }}</flux:label>
-                @if ($workItem->source_url)
+            @if ($workItem->source_url)
+                <div>
+                    <flux:label>{{ __('Source URL') }}</flux:label>
                     <flux:link href="{{ $workItem->source_url }}" target="_blank">
                         {{ $workItem->source_url }}
                     </flux:link>
-                @else
-                    <flux:text>{{ __('—') }}</flux:text>
-                @endif
-            </div>
+                </div>
+            @endif
 
             <div>
                 <flux:label>{{ __('Created') }}</flux:label>

--- a/tests/Feature/WorkItemCrudTest.php
+++ b/tests/Feature/WorkItemCrudTest.php
@@ -81,6 +81,47 @@ it('shows the work item detail page', function () {
         ->assertSee($this->workItem->title);
 });
 
+it('hides empty optional fields on work item detail page', function () {
+    $workItem = WorkItem::factory()->for($this->organization)->create([
+        'description' => '',
+        'board_id' => '',
+        'source' => 'github',
+        'source_reference' => '',
+        'source_url' => null,
+        'project_id' => null,
+    ]);
+
+    Livewire\Livewire::actingAs($this->user)
+        ->test('pages::work-items.show', ['workItem' => $workItem])
+        ->assertDontSee('Board ID')
+        ->assertDontSee('Source Reference')
+        ->assertDontSee('Source URL')
+        ->assertDontSee('Project')
+        ->assertDontSee('Description');
+});
+
+it('shows populated optional fields on work item detail page', function () {
+    $workItem = WorkItem::factory()->for($this->organization)->forProject($this->project)->create([
+        'description' => 'A detailed description',
+        'board_id' => 'BOARD-123',
+        'source' => 'github',
+        'source_reference' => 'org/repo#5',
+        'source_url' => 'https://github.com/org/repo/issues/5',
+    ]);
+
+    Livewire\Livewire::actingAs($this->user)
+        ->test('pages::work-items.show', ['workItem' => $workItem])
+        ->assertSee('Board ID')
+        ->assertSee('BOARD-123')
+        ->assertSee('Source Reference')
+        ->assertSee('org/repo#5')
+        ->assertSee('Source URL')
+        ->assertSee('Project')
+        ->assertSee($this->project->name)
+        ->assertSee('Description')
+        ->assertSee('A detailed description');
+});
+
 it('can update a work item', function () {
     Livewire\Livewire::actingAs($this->user)
         ->test('pages::work-items.edit', ['workItem' => $this->workItem])


### PR DESCRIPTION
## Summary
- Hide optional fields (Board ID, Project, Source Reference, Source URL, Description) when they have no value, instead of displaying "—" placeholders
- Arrange metadata fields in a responsive two-column grid for a more compact layout
- Remove redundant Title field that was already displayed in the page heading

## Test plan
- [x] Added test verifying empty optional fields are hidden on the detail page
- [x] Added test verifying populated optional fields are shown on the detail page
- [x] All 12 WorkItemCrudTest tests pass

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)