### PR TITLE
Fix: show "Default" instead of "inherit" for agent model label

### DIFF
--- a/app/Models/Agent.php
+++ b/app/Models/Agent.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Concerns\BelongsToUserOrganization;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -37,6 +38,14 @@ class Agent extends Model
             'events' => 'array',
             'background' => 'boolean',
         ];
+    }
+
+    /**
+     * @return Attribute<string, never>
+     */
+    protected function modelDisplayName(): Attribute
+    {
+        return Attribute::get(fn (): string => $this->model === 'inherit' ? 'Default' : $this->model);
     }
 
     public function organization(): BelongsTo

--- a/resources/views/pages/agents/⚡index.blade.php
+++ b/resources/views/pages/agents/⚡index.blade.php
@@ -93,7 +93,7 @@ new #[Title('Agents')] class extends Component {
                             </flux:link>
                         </flux:table.cell>
                         <flux:table.cell>{{ $agent->provider }}</flux:table.cell>
-                        <flux:table.cell>{{ $agent->model }}</flux:table.cell>
+                        <flux:table.cell>{{ $agent->model_display_name }}</flux:table.cell>
                         <flux:table.cell>{{ $agent->organization->name }}</flux:table.cell>
                         <flux:table.cell align="end">
                             <div class="flex items-center justify-end gap-2">

--- a/resources/views/pages/agents/⚡show.blade.php
+++ b/resources/views/pages/agents/⚡show.blade.php
@@ -65,7 +65,7 @@ new #[Title('View Agent')] class extends Component {
 
             <div>
                 <flux:heading size="sm" class="text-zinc-500 dark:text-zinc-400">{{ __('Model') }}</flux:heading>
-                <flux:text>{{ $agent->model ?: __('None') }}</flux:text>
+                <flux:text>{{ $agent->model_display_name }}</flux:text>
             </div>
 
             <div>

--- a/tests/Feature/AgentCrudTest.php
+++ b/tests/Feature/AgentCrudTest.php
@@ -89,6 +89,22 @@ it('can delete an agent', function () {
     ]);
 });
 
+it('shows Default label for inherited model on index page', function () {
+    $this->agent->update(['model' => 'inherit']);
+
+    $this->actingAs($this->user)
+        ->get(route('agents.index'))
+        ->assertSee('Default');
+});
+
+it('shows actual model name on index page when set', function () {
+    $agent = Agent::factory()->for($this->organization)->create(['model' => 'claude-sonnet-4-6']);
+
+    $this->actingAs($this->user)
+        ->get(route('agents.index'))
+        ->assertSee('claude-sonnet-4-6');
+});
+
 it('prevents access to agents from other organizations', function () {
     $otherOrg = Organization::factory()->create();
     $otherAgent = Agent::factory()->for($otherOrg)->create();

--- a/tests/Feature/AgentTest.php
+++ b/tests/Feature/AgentTest.php
@@ -62,3 +62,15 @@ it('allows same name in different organizations', function () {
 
     expect($agent1->id)->not->toBe($agent2->id);
 });
+
+it('returns Default for model_display_name when model is inherit', function () {
+    $agent = Agent::factory()->create(['model' => 'inherit']);
+
+    expect($agent->model_display_name)->toBe('Default');
+});
+
+it('returns the model name for model_display_name when model is not inherit', function () {
+    $agent = Agent::factory()->create(['model' => 'claude-sonnet-4-6']);
+
+    expect($agent->model_display_name)->toBe('claude-sonnet-4-6');
+});


### PR DESCRIPTION
Closes #111

## Summary

The Agent model column on the index and show pages displayed the raw database value "inherit" which was unclear to users. This adds a `modelDisplayName` accessor to the Agent model that returns "Default" when the model is set to "inherit", and returns the actual model name otherwise. Both the agents index table and the agent detail page now use this accessor.

## Verification

1. Navigate to the Agents list page
2. Agents with `model` set to "inherit" now display "Default" in the Model column
3. Agents with a specific model (e.g. "claude-sonnet-4-6") display that model name
4. The agent detail/show page also displays "Default" instead of "inherit"