### PR TITLE
fix: remove event codes from Events tab in agent forms

### DIFF
--- a/resources/views/pages/agents/⚡create.blade.php
+++ b/resources/views/pages/agents/⚡create.blade.php
@@ -308,7 +308,7 @@ new #[Title('Create Agent')] class extends Component {
                                     <flux:heading size="xs" class="mb-2">{{ $section['label'] }}</flux:heading>
                                     <div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
                                         @foreach ($section['checkboxes'] as $checkbox)
-                                            <flux:checkbox :label="$checkbox['label']" :value="$checkbox['value']" :description="$checkbox['value']" />
+                                            <flux:checkbox :label="$checkbox['label']" :value="$checkbox['value']" />
                                         @endforeach
                                     </div>
 

--- a/resources/views/pages/agents/⚡edit.blade.php
+++ b/resources/views/pages/agents/⚡edit.blade.php
@@ -376,7 +376,7 @@ new #[Title('Edit Agent')] class extends Component {
                                     <flux:heading size="xs" class="mb-2">{{ $section['label'] }}</flux:heading>
                                     <div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
                                         @foreach ($section['checkboxes'] as $checkbox)
-                                            <flux:checkbox :label="$checkbox['label']" :value="$checkbox['value']" :description="$checkbox['value']" />
+                                            <flux:checkbox :label="$checkbox['label']" :value="$checkbox['value']" />
                                         @endforeach
                                     </div>
 

--- a/tests/Feature/AgentCrudTest.php
+++ b/tests/Feature/AgentCrudTest.php
@@ -105,6 +105,20 @@ it('shows actual model name on index page when set', function () {
         ->assertSee('claude-sonnet-4-6');
 });
 
+it('does not show event codes as descriptions in create form', function () {
+    Livewire\Livewire::actingAs($this->user)
+        ->test('pages::agents.create')
+        ->assertDontSeeHtml('<ui-description data-flux-description')
+        ->assertSeeHtml('Pushed');
+});
+
+it('does not show event codes as descriptions in edit form', function () {
+    Livewire\Livewire::actingAs($this->user)
+        ->test('pages::agents.edit', ['agent' => $this->agent])
+        ->assertDontSeeHtml('<ui-description data-flux-description')
+        ->assertSeeHtml('Pushed');
+});
+
 it('prevents access to agents from other organizations', function () {
     $otherOrg = Organization::factory()->create();
     $otherAgent = Agent::factory()->for($otherOrg)->create();


### PR DESCRIPTION
## Summary
- Removed the `:description` attribute from event checkboxes in the agent create and edit forms' Events tab
- The event codes (e.g. `push`, `issues.opened`) were being shown underneath each checkbox label, making the form unnecessarily tall
- Event titles/labels alone are sufficient for identifying each event

Closes #129

## Test plan
- [x] Added tests verifying no `<ui-description>` elements are rendered in the Events tab for both create and edit forms
- [x] Existing agent CRUD tests continue to pass (12 tests, 28 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)