### PR TITLE
fix: make repo optional when creating agents

### DIFF
--- a/app/Ai/ToolRegistry.php
+++ b/app/Ai/ToolRegistry.php
@@ -126,7 +126,7 @@ class ToolRegistry
         'reopen_work_item' => ['class' => ReopenWorkItemTool::class, 'description' => 'Reopen a closed work item', 'group' => 'Work Items', 'category' => 'pageant', 'flexible' => true],
 
         // Agents
-        'create_agent' => ['class' => CreateAgentTool::class, 'description' => 'Create a new agent', 'group' => 'Agents', 'category' => 'pageant', 'flexible' => true],
+        'create_agent' => ['class' => CreateAgentTool::class, 'description' => 'Create a new agent', 'group' => 'Agents', 'local' => true],
         'list_agents' => ['class' => ListAgentsTool::class, 'description' => 'List agents in the organization', 'group' => 'Agents', 'local' => true],
         'search_agents' => ['class' => SearchAgentsTool::class, 'description' => 'Search for agents matching work item requirements', 'group' => 'Agents', 'local' => true],
 

--- a/app/Ai/Tools/CreateAgentTool.php
+++ b/app/Ai/Tools/CreateAgentTool.php
@@ -5,9 +5,8 @@ namespace App\Ai\Tools;
 use App\Ai\EventRegistry;
 use App\Ai\ToolRegistry;
 use App\Models\Agent;
-use App\Models\GithubInstallation;
 use App\Models\Repo;
-use App\Services\GitHubService;
+use App\Models\User;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Tools\Request;
@@ -15,9 +14,7 @@ use Laravel\Ai\Tools\Request;
 class CreateAgentTool implements Tool
 {
     public function __construct(
-        protected GitHubService $github,
-        protected ?GithubInstallation $installation = null,
-        protected ?string $repoFullName = null,
+        protected User $user,
     ) {}
 
     public function description(): string
@@ -27,14 +24,15 @@ class CreateAgentTool implements Tool
 
     public function handle(Request $request): string
     {
-        $repoFullName = $this->repoFullName ?? $request['repo'];
+        $organizationId = $this->user->currentOrganizationId()
+            ?? $this->user->organizations()->first()?->id;
 
-        $repo = Repo::where('source', 'github')
-            ->where('source_reference', $repoFullName)
-            ->firstOrFail();
+        if (! $organizationId) {
+            return json_encode(['error' => 'No organization found for the current user.']);
+        }
 
         $data = [
-            'organization_id' => $repo->organization_id,
+            'organization_id' => $organizationId,
             'name' => $request['name'],
             'description' => $request['description'] ?? '',
             'tools' => $request['tools'] ?? [],
@@ -53,39 +51,35 @@ class CreateAgentTool implements Tool
 
         $agent = Agent::create($data);
 
-        $repoIds = [$repo->id];
+        $repoNames = $request['repo_names'] ?? [];
 
-        if (! empty($request['repo_names'])) {
-            $additionalRepoIds = Repo::where('source', 'github')
-                ->whereIn('source_reference', $request['repo_names'])
-                ->where('organization_id', $repo->organization_id)
+        if (! empty($request['repo'])) {
+            array_unshift($repoNames, $request['repo']);
+        }
+
+        if (! empty($repoNames)) {
+            $repoIds = Repo::where('source', 'github')
+                ->whereIn('source_reference', array_unique($repoNames))
+                ->where('organization_id', $organizationId)
                 ->pluck('id')
                 ->all();
 
-            $repoIds = array_unique(array_merge($repoIds, $additionalRepoIds));
+            $agent->repos()->sync($repoIds);
         }
-
-        $agent->repos()->sync($repoIds);
 
         return json_encode($agent->load('repos')->toArray(), JSON_PRETTY_PRINT);
     }
 
     public function schema(JsonSchema $schema): array
     {
-        $fields = [];
-
-        if (! $this->repoFullName) {
-            $fields['repo'] = $schema->string()
-                ->description('The repository in owner/repo format.')
-                ->required();
-        }
-
-        return array_merge($fields, [
+        return [
             'name' => $schema->string()
                 ->description('The name of the agent.')
                 ->required(),
             'description' => $schema->string()
                 ->description('A description of what the agent does, used as its system instructions.'),
+            'repo' => $schema->string()
+                ->description('A repository in owner/repo format to attach the agent to. Optional — the agent will be created in the user\'s current organization regardless.'),
             'tools' => $schema->array()
                 ->description('Tool names the agent can use. Available: '.implode(', ', array_keys(ToolRegistry::available()))),
             'events' => $schema->array()
@@ -107,6 +101,6 @@ class CreateAgentTool implements Tool
             'repo_names' => $schema->array()
                 ->items($schema->string())
                 ->description('Repository full names (owner/repo) to attach the agent to.'),
-        ]);
+        ];
     }
 }

--- a/app/Mcp/Tools/CreateAgentTool.php
+++ b/app/Mcp/Tools/CreateAgentTool.php
@@ -20,7 +20,7 @@ class CreateAgentTool extends Tool
     public function handle(Request $request): Response
     {
         $validated = $request->validate([
-            'repo' => 'required|string',
+            'repo' => 'nullable|string',
             'name' => 'required|string|max:255',
             'description' => 'nullable|string',
             'tools' => 'nullable|array',
@@ -37,7 +37,27 @@ class CreateAgentTool extends Tool
             'repo_names.*' => 'string',
         ]);
 
-        $repo = Repo::where('source', 'github')->where('source_reference', $validated['repo'])->firstOrFail();
+        $organizationId = null;
+
+        if (! empty($validated['repo'])) {
+            $repo = Repo::where('source', 'github')->where('source_reference', $validated['repo'])->first();
+            $organizationId = $repo?->organization_id;
+        }
+
+        if (! $organizationId) {
+            $user = auth()->user();
+
+            if (! $user) {
+                return Response::text(json_encode(['error' => 'Authentication required to create agents.']));
+            }
+
+            $organizationId = $user->currentOrganizationId()
+                ?? $user->organizations()->first()?->id;
+        }
+
+        if (! $organizationId) {
+            return Response::text(json_encode(['error' => 'No organization found. Provide a repo or ensure you belong to an organization.']));
+        }
 
         $events = collect($validated['events'] ?? [])->map(function ($entry) {
             if (is_string($entry)) {
@@ -48,7 +68,7 @@ class CreateAgentTool extends Tool
         })->values()->toArray();
 
         $data = [
-            'organization_id' => $repo->organization_id,
+            'organization_id' => $organizationId,
             'name' => $validated['name'],
             'description' => $validated['description'] ?? '',
             'tools' => $validated['tools'] ?? [],
@@ -67,19 +87,21 @@ class CreateAgentTool extends Tool
 
         $agent = Agent::create($data);
 
-        $repoIds = [$repo->id];
+        $repoNames = $validated['repo_names'] ?? [];
 
-        if (! empty($validated['repo_names'])) {
-            $additionalRepoIds = Repo::where('source', 'github')
-                ->whereIn('source_reference', $validated['repo_names'])
-                ->where('organization_id', $repo->organization_id)
+        if (! empty($validated['repo'])) {
+            array_unshift($repoNames, $validated['repo']);
+        }
+
+        if (! empty($repoNames)) {
+            $repoIds = Repo::where('source', 'github')
+                ->whereIn('source_reference', array_unique($repoNames))
+                ->where('organization_id', $organizationId)
                 ->pluck('id')
                 ->toArray();
 
-            $repoIds = array_unique(array_merge($repoIds, $additionalRepoIds));
+            $agent->repos()->sync($repoIds);
         }
-
-        $agent->repos()->sync($repoIds);
 
         return Response::text(json_encode($agent->load('repos')->toArray(), JSON_PRETTY_PRINT));
     }
@@ -91,8 +113,7 @@ class CreateAgentTool extends Tool
     {
         return [
             'repo' => $schema->string()
-                ->description('The repository in owner/repo format. The agent will be created in this repo\'s organization and attached to it.')
-                ->required(),
+                ->description('A repository in owner/repo format to attach the agent to. Optional — the agent will be created in the user\'s current organization if not provided.'),
             'name' => $schema->string()
                 ->description('The name of the agent.')
                 ->required(),

--- a/tests/Feature/CreateAgentToolTest.php
+++ b/tests/Feature/CreateAgentToolTest.php
@@ -1,15 +1,20 @@
 <?php
 
 use App\Ai\ToolRegistry;
+use App\Ai\Tools\CreateAgentTool as AiCreateAgentTool;
 use App\Mcp\Servers\PageantServer;
 use App\Mcp\Tools\CreateAgentTool;
 use App\Models\Agent;
 use App\Models\GithubInstallation;
 use App\Models\Organization;
 use App\Models\Repo;
+use App\Models\User;
 
 beforeEach(function () {
     $this->organization = Organization::factory()->create();
+    $this->user = User::factory()->create(['current_organization_id' => $this->organization->id]);
+    $this->user->organizations()->attach($this->organization);
+    $this->actingAs($this->user);
     $this->installation = GithubInstallation::factory()->create([
         'organization_id' => $this->organization->id,
     ]);
@@ -20,7 +25,7 @@ beforeEach(function () {
     ]);
 });
 
-it('creates an agent via MCP tool', function () {
+it('creates an agent via MCP tool with repo', function () {
     $response = PageantServer::tool(CreateAgentTool::class, [
         'repo' => 'acme/widgets',
         'name' => 'review-bot',
@@ -43,6 +48,22 @@ it('creates an agent via MCP tool', function () {
         ->and($agent->provider)->toBe('anthropic')
         ->and($agent->enabled)->toBeTrue()
         ->and($agent->repos->pluck('id'))->toContain($this->repo->id);
+});
+
+it('creates an agent via MCP tool without repo', function () {
+    $response = PageantServer::tool(CreateAgentTool::class, [
+        'name' => 'org-bot',
+        'description' => 'Manages organization tasks',
+    ]);
+
+    $response->assertOk()
+        ->assertSee('org-bot');
+
+    $agent = Agent::where('name', 'org-bot')->first();
+
+    expect($agent)->not->toBeNull()
+        ->and($agent->organization_id)->toBe($this->organization->id)
+        ->and($agent->repos)->toHaveCount(0);
 });
 
 it('creates an agent with subscription objects via MCP tool', function () {
@@ -68,7 +89,6 @@ it('creates an agent with subscription objects via MCP tool', function () {
 
 it('creates an agent with defaults via MCP tool', function () {
     $response = PageantServer::tool(CreateAgentTool::class, [
-        'repo' => 'acme/widgets',
         'name' => 'simple-bot',
     ]);
 
@@ -110,4 +130,48 @@ it('registers create_agent in the AI ToolRegistry', function () {
     $available = ToolRegistry::available();
 
     expect($available)->toHaveKey('create_agent');
+});
+
+it('creates an agent via AI tool without repo', function () {
+    $tool = new AiCreateAgentTool($this->user);
+
+    $result = $tool->handle(new \Laravel\Ai\Tools\Request([
+        'name' => 'no-repo-bot',
+        'description' => 'Agent without a repo',
+    ]));
+
+    $decoded = json_decode($result, true);
+
+    expect($decoded['name'])->toBe('no-repo-bot')
+        ->and($decoded['organization_id'])->toBe($this->organization->id)
+        ->and($decoded['repos'])->toBeEmpty();
+});
+
+it('creates an agent via AI tool with repo attachment', function () {
+    $tool = new AiCreateAgentTool($this->user);
+
+    $result = $tool->handle(new \Laravel\Ai\Tools\Request([
+        'name' => 'repo-bot',
+        'repo' => 'acme/widgets',
+    ]));
+
+    $decoded = json_decode($result, true);
+
+    expect($decoded['name'])->toBe('repo-bot')
+        ->and($decoded['repos'])->toHaveCount(1)
+        ->and($decoded['repos'][0]['source_reference'])->toBe('acme/widgets');
+});
+
+it('returns error via AI tool when user has no organization', function () {
+    $orphanUser = User::factory()->create();
+    $tool = new AiCreateAgentTool($orphanUser);
+
+    $result = $tool->handle(new \Laravel\Ai\Tools\Request([
+        'name' => 'orphan-bot',
+    ]));
+
+    $decoded = json_decode($result, true);
+
+    expect($decoded)->toHaveKey('error')
+        ->and($decoded['error'])->toContain('No organization');
 });

--- a/tests/Feature/FlexibleToolsTest.php
+++ b/tests/Feature/FlexibleToolsTest.php
@@ -5,6 +5,7 @@ use App\Ai\Tools\CloseWorkItemTool;
 use App\Ai\Tools\CreateAgentTool;
 use App\Ai\Tools\CreateWorkItemTool;
 use App\Ai\Tools\ReopenWorkItemTool;
+use App\Models\User;
 
 it('includes flexible tools in availableForContext when no repo is selected', function () {
     $available = ToolRegistry::availableForContext(null);
@@ -39,13 +40,21 @@ it('includes all tools in availableForContext when a repo is selected', function
 });
 
 it('resolves flexible tools without a repo context', function () {
-    $tools = ToolRegistry::resolve(['create_work_item', 'close_work_item', 'reopen_work_item', 'create_agent'], null);
+    $tools = ToolRegistry::resolve(['create_work_item', 'close_work_item', 'reopen_work_item'], null);
 
-    expect($tools)->toHaveCount(4)
+    expect($tools)->toHaveCount(3)
         ->and($tools[0])->toBeInstanceOf(CreateWorkItemTool::class)
         ->and($tools[1])->toBeInstanceOf(CloseWorkItemTool::class)
-        ->and($tools[2])->toBeInstanceOf(ReopenWorkItemTool::class)
-        ->and($tools[3])->toBeInstanceOf(CreateAgentTool::class);
+        ->and($tools[2])->toBeInstanceOf(ReopenWorkItemTool::class);
+});
+
+it('resolves create_agent as a local tool with a user', function () {
+    $user = User::factory()->create();
+
+    $tools = ToolRegistry::resolve(['create_agent'], null, $user);
+
+    expect($tools)->toHaveCount(1)
+        ->and($tools[0])->toBeInstanceOf(CreateAgentTool::class);
 });
 
 it('requires repo parameter in schema when no repo context is provided', function () {
@@ -68,4 +77,15 @@ it('omits repo parameter in schema when repo context is provided', function () {
     $fields = $tool->schema($schema);
 
     expect($fields)->not->toHaveKey('repo');
+});
+
+it('does not require repo in create_agent schema', function () {
+    $user = User::factory()->create();
+    $tool = new CreateAgentTool($user);
+    $schema = new \Illuminate\JsonSchema\JsonSchemaTypeFactory;
+
+    $fields = $tool->schema($schema);
+
+    expect($fields)->toHaveKey('repo')
+        ->and($fields)->toHaveKey('name');
 });


### PR DESCRIPTION
## Summary

- Made the `repo` parameter optional in both `App\Ai\Tools\CreateAgentTool` and `App\Mcp\Tools\CreateAgentTool`, resolving the organization from the authenticated user instead of requiring a repo lookup
- Changed `create_agent` from a `flexible` tool to a `local` tool in the `ToolRegistry`, matching the pattern used by `CreateSkillTool` and other organization-scoped tools
- When `repo` or `repo_names` are provided, they are used to attach repos to the agent after creation

This fixes the assistant getting stuck in a loop when trying to create an agent without a repo in context -- the tool schema previously marked `repo` as required, so the assistant would repeatedly attempt to determine which repo to use.

Closes #127

## Test plan

- [x] Existing MCP CreateAgentTool tests updated and passing (with and without repo)
- [x] New AI CreateAgentTool tests: creation without repo, creation with repo attachment, error when user has no organization
- [x] FlexibleToolsTest updated: `create_agent` now resolves as a local tool with a user
- [x] All 29 related tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)