### PR TITLE
fix: work item close/reopen buttons spin on all buttons and don't update UI

### DIFF
--- a/resources/views/pages/work-items/⚡index.blade.php
+++ b/resources/views/pages/work-items/⚡index.blade.php
@@ -203,6 +203,7 @@ new #[Title('Work Items')] class extends Component {
         $workItem = WorkItem::query()->forCurrentOrganization()->findOrFail($id);
         $workItem->update(['status' => 'closed']);
 
+        unset($this->workItems);
         $this->dispatch('close-modal', id: 'confirm-close-' . $id);
     }
 
@@ -210,6 +211,8 @@ new #[Title('Work Items')] class extends Component {
     {
         $workItem = WorkItem::query()->forCurrentOrganization()->findOrFail($id);
         $workItem->update(['status' => 'open']);
+
+        unset($this->workItems);
     }
 }; ?>
 
@@ -311,11 +314,11 @@ new #[Title('Work Items')] class extends Component {
                                         {{ __('Edit') }}
                                     </flux:button>
                                     @if ($workItem->isOpen())
-                                        <flux:button size="sm" variant="ghost" wire:click="confirmClose('{{ $workItem->id }}')">
+                                        <flux:button size="sm" variant="ghost" wire:click="confirmClose('{{ $workItem->id }}')" wire:target="confirmClose('{{ $workItem->id }}')">
                                             {{ __('Close') }}
                                         </flux:button>
                                     @else
-                                        <flux:button size="sm" wire:click="reopen('{{ $workItem->id }}')">
+                                        <flux:button size="sm" wire:click="reopen('{{ $workItem->id }}')" wire:target="reopen('{{ $workItem->id }}')">
                                             {{ __('Reopen') }}
                                         </flux:button>
                                     @endif
@@ -327,7 +330,7 @@ new #[Title('Work Items')] class extends Component {
                                         <flux:text>{{ __('Are you sure you want to close ":title"?', ['title' => $workItem->title]) }}</flux:text>
                                         <div class="flex justify-end gap-3">
                                             <flux:button x-on:click="$flux.modal.close()">{{ __('Cancel') }}</flux:button>
-                                            <flux:button variant="danger" wire:click="close('{{ $workItem->id }}')">{{ __('Close') }}</flux:button>
+                                            <flux:button variant="danger" wire:click="close('{{ $workItem->id }}')" wire:target="close('{{ $workItem->id }}')">{{ __('Close') }}</flux:button>
                                         </div>
                                     </div>
                                 </flux:modal>
@@ -416,16 +419,16 @@ new #[Title('Work Items')] class extends Component {
                                         </div>
                                     </div>
                                     <div class="ml-3 shrink-0">
-                                        <template x-if="tracked.includes(issueKey(issue))">
-                                            <flux:button size="sm" variant="ghost" x-on:click="$wire.untrackIssue(issueKey(issue)); $dispatch('issue-untracked', { sourceReference: issueKey(issue) })">
-                                                {{ __('Remove') }}
+                                        <div x-show="tracked.includes(issueKey(issue))">
+                                            <flux:button size="sm" variant="danger" x-on:click="$wire.untrackIssue(issueKey(issue)); $dispatch('issue-untracked', { sourceReference: issueKey(issue) })">
+                                                {{ __('Untrack') }}
                                             </flux:button>
-                                        </template>
-                                        <template x-if="!tracked.includes(issueKey(issue))">
+                                        </div>
+                                        <div x-show="!tracked.includes(issueKey(issue))">
                                             <flux:button size="sm" variant="primary" x-on:click="$wire.trackIssue(issue.number, issue.title, issue.html_url); $dispatch('issue-tracked', { sourceReference: issueKey(issue) })">
                                                 {{ __('Track') }}
                                             </flux:button>
-                                        </template>
+                                        </div>
                                     </div>
                                 </div>
                             </template>

--- a/resources/views/pages/work-items/⚡show.blade.php
+++ b/resources/views/pages/work-items/⚡show.blade.php
@@ -91,11 +91,15 @@ new #[Title('Work Item')] class extends Component {
     public function close(): void
     {
         $this->workItem->update(['status' => 'closed']);
+        $this->workItem->refresh();
+
+        $this->dispatch('close-modal', id: 'confirm-close');
     }
 
     public function reopen(): void
     {
         $this->workItem->update(['status' => 'open']);
+        $this->workItem->refresh();
     }
 }; ?>
 
@@ -116,11 +120,11 @@ new #[Title('Work Item')] class extends Component {
                     {{ __('Edit') }}
                 </flux:button>
                 @if ($workItem->isOpen())
-                    <flux:button variant="ghost" wire:click="confirmClose">
+                    <flux:button variant="ghost" wire:click="confirmClose" wire:target="confirmClose">
                         {{ __('Close') }}
                     </flux:button>
                 @else
-                    <flux:button wire:click="reopen">
+                    <flux:button wire:click="reopen" wire:target="reopen">
                         {{ __('Reopen') }}
                     </flux:button>
                 @endif
@@ -305,7 +309,7 @@ new #[Title('Work Item')] class extends Component {
                 <flux:text>{{ __('Are you sure you want to close ":title"?', ['title' => $workItem->title]) }}</flux:text>
                 <div class="flex justify-end gap-3">
                     <flux:button x-on:click="$flux.modal.close()">{{ __('Cancel') }}</flux:button>
-                    <flux:button variant="danger" wire:click="close">{{ __('Close') }}</flux:button>
+                    <flux:button variant="danger" wire:click="close" wire:target="close">{{ __('Close') }}</flux:button>
                 </div>
             </div>
         </flux:modal>

--- a/tests/Feature/WorkItemCrudTest.php
+++ b/tests/Feature/WorkItemCrudTest.php
@@ -134,20 +134,40 @@ it('can update a work item', function () {
     expect($this->workItem->fresh()->title)->toBe('Updated Work Item');
 });
 
-it('can close a work item', function () {
+it('can close a work item from the index', function () {
     Livewire\Livewire::actingAs($this->user)
         ->test('pages::work-items.index')
-        ->call('close', $this->workItem->id);
+        ->call('close', $this->workItem->id)
+        ->assertDispatched('close-modal', id: 'confirm-close-'.$this->workItem->id);
 
     expect($this->workItem->fresh()->status)->toBe('closed');
 });
 
-it('can reopen a closed work item', function () {
+it('can reopen a closed work item from the index', function () {
     $this->workItem->update(['status' => 'closed']);
 
     Livewire\Livewire::actingAs($this->user)
         ->test('pages::work-items.index')
         ->call('reopen', $this->workItem->id);
+
+    expect($this->workItem->fresh()->status)->toBe('open');
+});
+
+it('can close a work item from the show page', function () {
+    Livewire\Livewire::actingAs($this->user)
+        ->test('pages::work-items.show', ['workItem' => $this->workItem])
+        ->call('close')
+        ->assertDispatched('close-modal', id: 'confirm-close');
+
+    expect($this->workItem->fresh()->status)->toBe('closed');
+});
+
+it('can reopen a closed work item from the show page', function () {
+    $this->workItem->update(['status' => 'closed']);
+
+    Livewire\Livewire::actingAs($this->user)
+        ->test('pages::work-items.show', ['workItem' => $this->workItem])
+        ->call('reopen');
 
     expect($this->workItem->fresh()->status)->toBe('open');
 });


### PR DESCRIPTION
Closes #133

## Summary
- Scoped `wire:target` on Close/Reopen buttons so loading indicators only appear on the clicked button, not all buttons in the component
- Invalidated computed `workItems` cache after close/reopen on the index page so the list re-renders
- Added `$this->workItem->refresh()` and modal dismissal after close/reopen on the show page
- Replaced `x-if` with `x-show` for track/untrack buttons in the import modal to fix rendering (Flux components inside `<template x-if>` lose styling)
- Renamed "Remove" to "Untrack" with `variant="danger"` for clarity

## Verification
1. Go to Work Items index, click Close on a work item — only that button should spin, modal appears, confirming closes the item and updates the list
2. Go to a Work Item show page, click Close — modal appears, confirming closes the item, badge updates to Closed, Reopen button appears
3. Import Issues modal — Track/Untrack buttons render correctly with proper styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)