### PR TITLE
fix: use foreignUuid for planning_agent_id migration

### DIFF
--- a/database/migrations/2026_03_09_041431_add_planning_agent_id_to_organizations.php
+++ b/database/migrations/2026_03_09_041431_add_planning_agent_id_to_organizations.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('organizations', function (Blueprint $table) {
-            $table->foreignId('planning_agent_id')->nullable()->constrained('agents')->nullOnDelete();
+            $table->foreignUuid('planning_agent_id')->nullable()->constrained('agents')->nullOnDelete();
         });
     }
 


### PR DESCRIPTION
## Summary

The agents table uses UUID primary keys (`HasUuids`), but the migration used `foreignId()` which creates a `bigint` column. PostgreSQL rejects the foreign key constraint due to type mismatch. Changed to `foreignUuid()`.

## Verification

Run `php artisan migrate` — the `planning_agent_id` column should be created as UUID with a valid foreign key constraint.