### PR TITLE
fix: single CTA on empty index pages

### DIFF
--- a/resources/views/pages/agents/⚡index.blade.php
+++ b/resources/views/pages/agents/⚡index.blade.php
@@ -75,11 +75,6 @@ new #[Title('Agents')] class extends Component {
                 <x-slot:icon>
                     <flux:icon.cpu-chip class="size-10 text-zinc-400 dark:text-zinc-500" />
                 </x-slot:icon>
-                <x-slot:action>
-                    <flux:button variant="primary" href="{{ route('agents.create') }}" wire:navigate>
-                        {{ __('Create Agent') }}
-                    </flux:button>
-                </x-slot:action>
             </x-empty-state>
         @else
             <flux:input wire:model.live="search" placeholder="{{ __('Search agents...') }}" icon="magnifying-glass" />

--- a/resources/views/pages/projects/⚡index.blade.php
+++ b/resources/views/pages/projects/⚡index.blade.php
@@ -73,11 +73,6 @@ new #[Title('Projects')] class extends Component {
                 <x-slot:icon>
                     <flux:icon.folder class="size-10 text-zinc-400 dark:text-zinc-500" />
                 </x-slot:icon>
-                <x-slot:action>
-                    <flux:button variant="primary" href="{{ route('projects.create') }}" wire:navigate>
-                        {{ __('Create Project') }}
-                    </flux:button>
-                </x-slot:action>
             </x-empty-state>
         @else
             <flux:input wire:model.live.debounce.300ms="search" placeholder="{{ __('Search projects...') }}" icon="magnifying-glass" />

--- a/resources/views/pages/repos/⚡index.blade.php
+++ b/resources/views/pages/repos/⚡index.blade.php
@@ -177,11 +177,6 @@ new #[Title('Repos')] class extends Component {
                 <x-slot:icon>
                     <flux:icon.code-bracket class="size-10 text-zinc-400 dark:text-zinc-500" />
                 </x-slot:icon>
-                <x-slot:action>
-                    <flux:button variant="primary" wire:click="openImportModal">
-                        {{ __('Import Repo') }}
-                    </flux:button>
-                </x-slot:action>
             </x-empty-state>
         @else
             <flux:input wire:model.live="search" placeholder="{{ __('Search repos...') }}" icon="magnifying-glass" />

--- a/resources/views/pages/skills/⚡index.blade.php
+++ b/resources/views/pages/skills/⚡index.blade.php
@@ -80,11 +80,6 @@ new #[Title('Skills')] class extends Component {
                 <x-slot:icon>
                     <flux:icon.bolt class="size-10 text-zinc-400 dark:text-zinc-500" />
                 </x-slot:icon>
-                <x-slot:action>
-                    <flux:button variant="primary" href="{{ route('skills.create') }}" wire:navigate>
-                        {{ __('Create Skill') }}
-                    </flux:button>
-                </x-slot:action>
             </x-empty-state>
         @else
             <flux:input wire:model.live="search" placeholder="{{ __('Search skills...') }}" icon="magnifying-glass" />

--- a/resources/views/pages/work-items/⚡index.blade.php
+++ b/resources/views/pages/work-items/⚡index.blade.php
@@ -248,11 +248,6 @@ new #[Title('Work Items')] class extends Component {
                 <x-slot:icon>
                     <flux:icon.clipboard-document-list class="size-10 text-zinc-400 dark:text-zinc-500" />
                 </x-slot:icon>
-                <x-slot:action>
-                    <flux:button variant="primary" wire:click="openImportModal">
-                        {{ __('Import Issues') }}
-                    </flux:button>
-                </x-slot:action>
             </x-empty-state>
         @else
             <div class="flex items-center gap-4">


### PR DESCRIPTION
## Summary

When an index page (agents, projects, skills, repos, work items) was empty, users saw two identical buttons: one in the toolbar (top-right) and one in the center of the empty state panel. This removes the duplicate by keeping only the toolbar button.

Empty states now show icon, heading, and description. The primary action (Create X / Import Repo / Import Issues) stays consistently in the toolbar across all index pages.

Made with [Cursor](https://cursor.com)